### PR TITLE
Update Android plugin to use latest snapshot of Gradle

### DIFF
--- a/unified-prototype/README.md
+++ b/unified-prototype/README.md
@@ -31,6 +31,7 @@ The `StandaloneAndroidLibraryPlugin` plugin works by using `project.afterEvaluat
 ### Limitations
 
 The Android example is currently limited, and does not support many use cases such as adding tests or running the `publish` task.
+It requires JDK >= 17 to build.
 
 ### Running 
 From the `testbed-android` directory, run `build` using the Gradle wrapper in the parent directory:

--- a/unified-prototype/gradle/wrapper/gradle-wrapper.properties
+++ b/unified-prototype/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-8.8-20240220001317+0000-bin.zip
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-8.8-20240303001623+0000-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/unified-prototype/gradlew
+++ b/unified-prototype/gradlew
@@ -55,7 +55,7 @@
 #       Darwin, MinGW, and NonStop.
 #
 #   (3) This script is generated from the Groovy template
-#       https://github.com/gradle/gradle/blob/HEAD/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+#       https://github.com/gradle/gradle/blob/HEAD/platforms/jvm/plugins-application/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
 #       within the Gradle project.
 #
 #       You can find Gradle at https://github.com/gradle/gradle/.

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/AndroidLibrary.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/AndroidLibrary.java
@@ -52,7 +52,6 @@ public abstract class AndroidLibrary {
     /**
      * Common dependencies for all targets.
      */
-    @Restricted
     public LibraryDependencies getDependencies() {
         return dependencies;
     }
@@ -65,7 +64,6 @@ public abstract class AndroidLibrary {
     /**
      * Static targets extension block.
      */
-    @Restricted
     public AndroidTargets getTargets() {
         return targets;
     }

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/AndroidTarget.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/AndroidTarget.java
@@ -33,7 +33,6 @@ public abstract class AndroidTarget implements Named {
     /**
      * Dependencies for this target.
      */
-    @Restricted
     public LibraryDependencies getDependencies() {
         return dependencies;
     }

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/AndroidTargets.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/AndroidTargets.java
@@ -14,7 +14,6 @@ public abstract class AndroidTargets {
         this.release = release;
     }
 
-    @Restricted
     public AndroidTarget getDebug() {
         return debug;
     }
@@ -24,7 +23,6 @@ public abstract class AndroidTargets {
         action.execute(getDebug());
     }
 
-    @Restricted
     public AndroidTarget getRelease() {
         return release;
     }

--- a/unified-prototype/unified-plugin/plugin-common/src/main/java/org/gradle/api/experimental/common/LibraryDependencies.java
+++ b/unified-prototype/unified-plugin/plugin-common/src/main/java/org/gradle/api/experimental/common/LibraryDependencies.java
@@ -4,7 +4,6 @@ import org.gradle.api.artifacts.dsl.DependencyCollector;
 import org.gradle.api.artifacts.dsl.GradleDependencies;
 import org.gradle.api.plugins.jvm.PlatformDependencyModifiers;
 import org.gradle.api.plugins.jvm.TestFixturesDependencyModifiers;
-import org.gradle.declarative.dsl.model.annotations.Adding;
 import org.gradle.declarative.dsl.model.annotations.Restricted;
 
 /**
@@ -20,16 +19,4 @@ public interface LibraryDependencies extends PlatformDependencyModifiers, TestFi
     // CompileOnlyApi is not included here, since both Android and KMP do not support it.
     // Does that mean we should also reconsider if we should support it? Or, should we
     // talk to Android and KMP about adding support
-
-    // TODO: This is an abuse of @Adding
-    @Adding
-    default void api(String notation) {
-        getApi().add(notation);
-    }
-
-    // TODO: This is an abuse of @Adding
-    @Adding
-    default void implementation(String notation) {
-        getImplementation().add(notation);
-    }
 }


### PR DESCRIPTION
- Prune unnecessary code from plugins now that DependencyCollector functions are extracted and dependency-adding methods are implicitly available.