### PR TITLE
Add a `javaLibrary` software type.

### DIFF
--- a/unified-prototype/README.md
+++ b/unified-prototype/README.md
@@ -4,7 +4,20 @@ This directory contains prototypes of plugins for JVM, Android, and KMP projects
 
 Currently, these different ecosystems still apply distinct plugins, but those plugins all share a common `plugin-common` dependency, which will gradually grow to contain more functionality.
 
-So far, the only example modified to use the Declarative DSL is the Android example.
+So far, only the Android and Java examples have been modified to use the Declarative DSL.
+
+## Java
+
+Sample Java projects live in the `testbed-java-library` and `testbed-java-application` directories.
+They have been updated to use the Declarative Gradle DSL.
+
+These samples show the definition of a simple Java application and library that target a single version of Java.
+
+To run the application, use:
+
+```
+> ./gradlew testbed-java-application:run
+```
 
 ## JVM
 

--- a/unified-prototype/settings.gradle.kts
+++ b/unified-prototype/settings.gradle.kts
@@ -9,6 +9,7 @@ pluginManagement {
 
 plugins {
     id("org.gradle.experimental.android-ecosystem")
+    id("org.gradle.experimental.jvm-ecosystem")
     id("org.gradle.experimental.kmp-ecosystem")
 }
 
@@ -27,3 +28,4 @@ include("testbed-kmp")
 include("testbed-jvm")
 include("testbed-jvm-groovy")
 include("testbed-java-application")
+include("testbed-java-library")

--- a/unified-prototype/testbed-java-application/build.gradle.something
+++ b/unified-prototype/testbed-java-application/build.gradle.something
@@ -1,7 +1,3 @@
-plugins {
-    id("org.gradle.experimental.java-application")
-}
-
 javaApplication {
     javaVersion = 21
     mainClass = "com.example.App"

--- a/unified-prototype/testbed-java-application/build.gradle.something
+++ b/unified-prototype/testbed-java-application/build.gradle.something
@@ -1,4 +1,8 @@
 javaApplication {
     javaVersion = 21
     mainClass = "com.example.App"
+
+    dependencies {
+        implementation("com.google.guava:guava:32.1.3-jre")
+    }
 }

--- a/unified-prototype/testbed-java-application/src/main/java/com/example/App.java
+++ b/unified-prototype/testbed-java-application/src/main/java/com/example/App.java
@@ -1,6 +1,11 @@
 package com.example;
 
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ListMultimap;
+
 public class App {
+    private final ListMultimap<String, Long> values = ImmutableListMultimap.of();
+
     public static void main(String[] args) {
         System.out.println("Hello from Java " + System.getProperty("java.version"));
     }

--- a/unified-prototype/testbed-java-library/build.gradle.something
+++ b/unified-prototype/testbed-java-library/build.gradle.something
@@ -1,3 +1,7 @@
 javaLibrary {
     javaVersion = 21
+
+    dependencies {
+        implementation("com.google.guava:guava:32.1.3-jre")
+    }
 }

--- a/unified-prototype/testbed-java-library/build.gradle.something
+++ b/unified-prototype/testbed-java-library/build.gradle.something
@@ -1,0 +1,3 @@
+javaLibrary {
+    javaVersion = 21
+}

--- a/unified-prototype/testbed-java-library/src/main/java/com/example/lib/Library.java
+++ b/unified-prototype/testbed-java-library/src/main/java/com/example/lib/Library.java
@@ -1,0 +1,4 @@
+package com.example.lib;
+
+public class Library {
+}

--- a/unified-prototype/testbed-java-library/src/main/java/com/example/lib/Library.java
+++ b/unified-prototype/testbed-java-library/src/main/java/com/example/lib/Library.java
@@ -1,4 +1,8 @@
 package com.example.lib;
 
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ListMultimap;
+
 public class Library {
+    private final ListMultimap<String, Long> values = ImmutableListMultimap.of();
 }

--- a/unified-prototype/unified-plugin/plugin-jvm/build.gradle.kts
+++ b/unified-prototype/unified-plugin/plugin-jvm/build.gradle.kts
@@ -14,6 +14,10 @@ gradlePlugin {
             id = "org.gradle.experimental.jvm-library"
             implementationClass = "org.gradle.api.experimental.jvm.StandaloneJvmLibraryPlugin"
         }
+        create("java-library") {
+            id = "org.gradle.experimental.java-library"
+            implementationClass = "org.gradle.api.experimental.java.StandaloneJavaLibraryPlugin"
+        }
         create("java-application") {
             id = "org.gradle.experimental.java-application"
             implementationClass = "org.gradle.api.experimental.java.StandaloneJavaApplicationPlugin"

--- a/unified-prototype/unified-plugin/plugin-jvm/build.gradle.kts
+++ b/unified-prototype/unified-plugin/plugin-jvm/build.gradle.kts
@@ -16,7 +16,7 @@ gradlePlugin {
         }
         create("java-application") {
             id = "org.gradle.experimental.java-application"
-            implementationClass = "org.gradle.api.experimental.jvm.StandaloneJavaApplicationPlugin"
+            implementationClass = "org.gradle.api.experimental.java.StandaloneJavaApplicationPlugin"
         }
         create("jvm-ecosystem") {
             id = "org.gradle.experimental.jvm-ecosystem"

--- a/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/java/JavaApplication.java
+++ b/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/java/JavaApplication.java
@@ -1,10 +1,22 @@
 package org.gradle.api.experimental.java;
 
+import org.gradle.api.Action;
+import org.gradle.api.experimental.common.ApplicationDependencies;
 import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Nested;
+import org.gradle.declarative.dsl.model.annotations.Configuring;
 import org.gradle.declarative.dsl.model.annotations.Restricted;
 
 @Restricted
 public interface JavaApplication extends JavaComponent {
     @Restricted
     Property<String> getMainClass();
+
+    @Nested
+    ApplicationDependencies getDependencies();
+
+    @Configuring
+    default void dependencies(Action<? super ApplicationDependencies> action) {
+        action.execute(getDependencies());
+    }
 }

--- a/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/java/JavaApplication.java
+++ b/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/java/JavaApplication.java
@@ -1,4 +1,4 @@
-package org.gradle.api.experimental.jvm;
+package org.gradle.api.experimental.java;
 
 import org.gradle.api.provider.Property;
 import org.gradle.declarative.dsl.model.annotations.Restricted;

--- a/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/java/JavaComponent.java
+++ b/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/java/JavaComponent.java
@@ -4,7 +4,7 @@ import org.gradle.api.provider.Property;
 import org.gradle.declarative.dsl.model.annotations.Restricted;
 
 @Restricted
-public interface JavaApplication extends JavaComponent {
+public interface JavaComponent {
     @Restricted
-    Property<String> getMainClass();
+    Property<Integer> getJavaVersion();
 }

--- a/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/java/JavaLibrary.java
+++ b/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/java/JavaLibrary.java
@@ -1,7 +1,18 @@
 package org.gradle.api.experimental.java;
 
+import org.gradle.api.Action;
+import org.gradle.api.experimental.common.LibraryDependencies;
+import org.gradle.api.tasks.Nested;
+import org.gradle.declarative.dsl.model.annotations.Configuring;
 import org.gradle.declarative.dsl.model.annotations.Restricted;
 
 @Restricted
 public interface JavaLibrary extends JavaComponent {
+    @Nested
+    LibraryDependencies getDependencies();
+
+    @Configuring
+    default void dependencies(Action<? super LibraryDependencies> action) {
+        action.execute(getDependencies());
+    }
 }

--- a/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/java/JavaLibrary.java
+++ b/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/java/JavaLibrary.java
@@ -1,0 +1,7 @@
+package org.gradle.api.experimental.java;
+
+import org.gradle.declarative.dsl.model.annotations.Restricted;
+
+@Restricted
+public interface JavaLibrary extends JavaComponent {
+}

--- a/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/java/StandaloneJavaApplicationPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/java/StandaloneJavaApplicationPlugin.java
@@ -1,4 +1,4 @@
-package org.gradle.api.experimental.jvm;
+package org.gradle.api.experimental.java;
 
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;

--- a/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/java/StandaloneJavaApplicationPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/java/StandaloneJavaApplicationPlugin.java
@@ -2,6 +2,7 @@ package org.gradle.api.experimental.java;
 
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.experimental.jvm.internal.JvmPluginSupport;
 import org.gradle.api.internal.plugins.software.SoftwareType;
 import org.gradle.api.plugins.ApplicationPlugin;
 import org.gradle.api.plugins.JavaPluginExtension;
@@ -30,5 +31,7 @@ abstract public class StandaloneJavaApplicationPlugin implements Plugin<Project>
 
         org.gradle.api.plugins.JavaApplication app = project.getExtensions().getByType(org.gradle.api.plugins.JavaApplication.class);
         app.getMainClass().set(dslModel.getMainClass());
+
+        JvmPluginSupport.linkSourceSetToDependencies(project, java.getSourceSets().getByName("main"), dslModel.getDependencies());
     }
 }

--- a/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/java/StandaloneJavaLibraryPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/java/StandaloneJavaLibraryPlugin.java
@@ -1,0 +1,34 @@
+package org.gradle.api.experimental.java;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.experimental.jvm.internal.JvmPluginSupport;
+import org.gradle.api.internal.plugins.software.SoftwareType;
+import org.gradle.api.plugins.JavaLibraryPlugin;
+import org.gradle.api.plugins.JavaPluginExtension;
+import org.gradle.jvm.toolchain.JavaLanguageVersion;
+
+/**
+ * Creates a declarative {@link JavaLibrary} DSL model, applies the official Java library plugin,
+ * and links the declarative model to the official plugin.
+ */
+public abstract class StandaloneJavaLibraryPlugin implements Plugin<Project> {
+    @SoftwareType(name = "javaLibrary", modelPublicType = JavaLibrary.class)
+    abstract public JavaLibrary getJavaApplication();
+
+    @Override
+    public void apply(Project project) {
+        JavaLibrary dslModel = getJavaApplication();
+
+        project.getPlugins().apply(JavaLibraryPlugin.class);
+
+        linkDslModelToPluginLazy(project, dslModel);
+    }
+
+    private void linkDslModelToPluginLazy(Project project, JavaLibrary dslModel) {
+        JavaPluginExtension java = project.getExtensions().getByType(JavaPluginExtension.class);
+        java.getToolchain().getLanguageVersion().set(dslModel.getJavaVersion().map(JavaLanguageVersion::of));
+
+        JvmPluginSupport.linkSourceSetToDependencies(project, java.getSourceSets().getByName("main"), dslModel.getDependencies());
+    }
+}

--- a/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/java/StandaloneJavaLibraryPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/java/StandaloneJavaLibraryPlugin.java
@@ -3,6 +3,7 @@ package org.gradle.api.experimental.java;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.experimental.jvm.internal.JvmPluginSupport;
+import org.gradle.api.experimental.jvm.internal.JvmPluginSupport;
 import org.gradle.api.internal.plugins.software.SoftwareType;
 import org.gradle.api.plugins.JavaLibraryPlugin;
 import org.gradle.api.plugins.JavaPluginExtension;

--- a/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/jvm/JvmEcosystemPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/jvm/JvmEcosystemPlugin.java
@@ -1,6 +1,7 @@
 package org.gradle.api.experimental.jvm;
 
 import org.gradle.api.Plugin;
+import org.gradle.api.experimental.java.StandaloneJavaApplicationPlugin;
 import org.gradle.api.initialization.Settings;
 import org.gradle.api.internal.SettingsInternal;
 import org.gradle.plugin.software.internal.SoftwareTypeRegistry;

--- a/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/jvm/JvmEcosystemPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/jvm/JvmEcosystemPlugin.java
@@ -2,6 +2,7 @@ package org.gradle.api.experimental.jvm;
 
 import org.gradle.api.Plugin;
 import org.gradle.api.experimental.java.StandaloneJavaApplicationPlugin;
+import org.gradle.api.experimental.java.StandaloneJavaLibraryPlugin;
 import org.gradle.api.initialization.Settings;
 import org.gradle.api.internal.SettingsInternal;
 import org.gradle.plugin.software.internal.SoftwareTypeRegistry;
@@ -13,6 +14,7 @@ public class JvmEcosystemPlugin implements Plugin<Settings> {
         SettingsInternal settings = (SettingsInternal) target;
         SoftwareTypeRegistry softwareTypeRegistry = settings.getServices().get(SoftwareTypeRegistry.class);
         softwareTypeRegistry.register(StandaloneJavaApplicationPlugin.class);
+        softwareTypeRegistry.register(StandaloneJavaLibraryPlugin.class);
         softwareTypeRegistry.register(StandaloneJvmLibraryPlugin.class);
     }
 }

--- a/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/jvm/StandaloneJvmLibraryPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/jvm/StandaloneJvmLibraryPlugin.java
@@ -3,6 +3,7 @@ package org.gradle.api.experimental.jvm;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.experimental.common.LibraryDependencies;
+import org.gradle.api.experimental.jvm.internal.JvmPluginSupport;
 import org.gradle.api.internal.plugins.software.SoftwareType;
 import org.gradle.api.plugins.JavaLibraryPlugin;
 import org.gradle.api.plugins.JavaPluginExtension;
@@ -32,7 +33,7 @@ abstract public class StandaloneJvmLibraryPlugin implements Plugin<Project> {
 
         SourceSet commonSources = JavaPluginHelper.getJavaComponent(project).getMainFeature().getSourceSet();
         commonSources.getJava().srcDirs(project.getLayout().getProjectDirectory().dir("src").dir("common").dir("java"));
-        linkSourceSetToDependencies(project, commonSources, dslModel.getDependencies());
+        JvmPluginSupport.linkSourceSetToDependencies(project, commonSources, dslModel.getDependencies());
 
         dslModel.getTargets().withType(JavaTarget.class).all(target -> {
             SourceSet sourceSet = java.getSourceSets().create("java" + target.getJavaVersion());
@@ -46,7 +47,7 @@ abstract public class StandaloneJvmLibraryPlugin implements Plugin<Project> {
             });
 
             // Link dependencies to DSL
-            linkSourceSetToDependencies(project, sourceSet, target.getDependencies());
+            JvmPluginSupport.linkSourceSetToDependencies(project, sourceSet, target.getDependencies());
 
             // Extend common sources
             sourceSet.getJava().srcDirs(commonSources.getAllJava());
@@ -61,16 +62,5 @@ abstract public class StandaloneJvmLibraryPlugin implements Plugin<Project> {
             project.getConfigurations().getByName(sourceSet.getApiConfigurationName())
                 .extendsFrom(project.getConfigurations().getByName(commonSources.getApiConfigurationName()));
         });
-    }
-
-    private void linkSourceSetToDependencies(Project project, SourceSet sourceSet, LibraryDependencies dependencies) {
-        project.getConfigurations().getByName(sourceSet.getImplementationConfigurationName())
-            .getDependencies().addAllLater(dependencies.getImplementation().getDependencies());
-        project.getConfigurations().getByName(sourceSet.getCompileOnlyConfigurationName())
-            .getDependencies().addAllLater(dependencies.getCompileOnly().getDependencies());
-        project.getConfigurations().getByName(sourceSet.getRuntimeOnlyConfigurationName())
-            .getDependencies().addAllLater(dependencies.getRuntimeOnly().getDependencies());
-        project.getConfigurations().getByName(sourceSet.getApiConfigurationName())
-            .getDependencies().addAllLater(dependencies.getApi().getDependencies());
     }
 }

--- a/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/jvm/internal/JvmPluginSupport.java
+++ b/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/jvm/internal/JvmPluginSupport.java
@@ -1,0 +1,29 @@
+package org.gradle.api.experimental.jvm.internal;
+
+import org.gradle.api.Project;
+import org.gradle.api.experimental.common.ApplicationDependencies;
+import org.gradle.api.experimental.common.LibraryDependencies;
+import org.gradle.api.tasks.SourceSet;
+
+public class JvmPluginSupport {
+    public static void linkSourceSetToDependencies(Project project, SourceSet sourceSet, LibraryDependencies dependencies) {
+        project.getConfigurations().getByName(sourceSet.getImplementationConfigurationName())
+                .getDependencies().addAllLater(dependencies.getImplementation().getDependencies());
+        project.getConfigurations().getByName(sourceSet.getCompileOnlyConfigurationName())
+                .getDependencies().addAllLater(dependencies.getCompileOnly().getDependencies());
+        project.getConfigurations().getByName(sourceSet.getRuntimeOnlyConfigurationName())
+                .getDependencies().addAllLater(dependencies.getRuntimeOnly().getDependencies());
+        project.getConfigurations().getByName(sourceSet.getApiConfigurationName())
+                .getDependencies().addAllLater(dependencies.getApi().getDependencies());
+    }
+
+    public static void linkSourceSetToDependencies(Project project, SourceSet sourceSet, ApplicationDependencies dependencies) {
+        project.getConfigurations().getByName(sourceSet.getImplementationConfigurationName())
+                .getDependencies().addAllLater(dependencies.getImplementation().getDependencies());
+        project.getConfigurations().getByName(sourceSet.getCompileOnlyConfigurationName())
+                .getDependencies().addAllLater(dependencies.getCompileOnly().getDependencies());
+        project.getConfigurations().getByName(sourceSet.getRuntimeOnlyConfigurationName())
+                .getDependencies().addAllLater(dependencies.getRuntimeOnly().getDependencies());
+    }
+
+}


### PR DESCRIPTION
This PR adds a basic `javaLibrary` software type.

The PR also adds a `dependencies { }` block to both `javaLibrary` and `javaApplication` software types.