### PR TITLE
Convert prototype plugins to use software types

### DIFF
--- a/unified-prototype/gradle/wrapper/gradle-wrapper.properties
+++ b/unified-prototype/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-8.8-20240329002018+0000-bin.zip
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-8.9-20240410113234+0000-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/unified-prototype/settings.gradle.kts
+++ b/unified-prototype/settings.gradle.kts
@@ -7,6 +7,11 @@ pluginManagement {
     includeBuild("unified-plugin")
 }
 
+plugins {
+    id("org.gradle.experimental.android-ecosystem")
+    id("org.gradle.experimental.kmp-ecosystem")
+}
+
 dependencyResolutionManagement {
     repositories {
         mavenCentral()

--- a/unified-prototype/testbed-android-application/build.gradle.something
+++ b/unified-prototype/testbed-android-application/build.gradle.something
@@ -1,7 +1,3 @@
-plugins {
-    id("org.gradle.experimental.android-application")
-}
-
 androidApplication {
     jdkVersion = 17
     compileSdk = 34

--- a/unified-prototype/testbed-android-library/build.gradle.something
+++ b/unified-prototype/testbed-android-library/build.gradle.something
@@ -1,7 +1,3 @@
-plugins {
-    id("org.gradle.experimental.android-library")
-}
-
 androidLibrary {
     jdkVersion = 17
     compileSdk = 34

--- a/unified-prototype/testbed-kmp/build.gradle.something
+++ b/unified-prototype/testbed-kmp/build.gradle.something
@@ -1,7 +1,3 @@
-plugins {
-    id("org.gradle.experimental.kmp-library")
-}
-
 kmpLibrary {
     dependencies {
         implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.4.1")

--- a/unified-prototype/unified-plugin/plugin-android/build.gradle.kts
+++ b/unified-prototype/unified-plugin/plugin-android/build.gradle.kts
@@ -20,6 +20,10 @@ gradlePlugin {
             id = "org.gradle.experimental.android-application"
             implementationClass = "org.gradle.api.experimental.android.application.StandaloneAndroidApplicationPlugin"
         }
+        create("android-ecosystem-plugin") {
+            id = "org.gradle.experimental.android-ecosystem"
+            implementationClass = "org.gradle.api.experimental.android.AndroidEcosystemPlugin"
+        }
     }
 }
 

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/AndroidEcosystemPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/AndroidEcosystemPlugin.java
@@ -1,0 +1,20 @@
+package org.gradle.api.experimental.android;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.experimental.android.application.StandaloneAndroidApplicationPlugin;
+import org.gradle.api.experimental.android.library.StandaloneAndroidLibraryPlugin;
+import org.gradle.api.initialization.Settings;
+import org.gradle.api.internal.SettingsInternal;
+import org.gradle.plugin.software.internal.SoftwareTypeRegistry;
+
+public class AndroidEcosystemPlugin implements Plugin<Settings> {
+
+    @Override
+    public void apply(Settings target) {
+        // To be replaced with static annotations once https://github.com/gradle/gradle/pull/28736 is merged
+        SettingsInternal settings = (SettingsInternal) target;
+        SoftwareTypeRegistry softwareTypeRegistry = settings.getServices().get(SoftwareTypeRegistry.class);
+        softwareTypeRegistry.register(StandaloneAndroidApplicationPlugin.class);
+        softwareTypeRegistry.register(StandaloneAndroidLibraryPlugin.class);
+    }
+}

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/application/StandaloneAndroidApplicationPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/application/StandaloneAndroidApplicationPlugin.java
@@ -9,6 +9,7 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.experimental.common.ApplicationDependencies;
+import org.gradle.api.internal.plugins.software.SoftwareType;
 import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension;
 
 import static org.gradle.api.experimental.android.AndroidDSLSupport.ifPresent;
@@ -18,9 +19,12 @@ import static org.gradle.api.experimental.android.AndroidDSLSupport.ifPresent;
  * and links the declarative model to the official plugin.
  */
 public abstract class StandaloneAndroidApplicationPlugin implements Plugin<Project> {
+    @SoftwareType(name = "androidApplication", modelPublicType=AndroidApplication.class)
+    abstract public AndroidApplication getAndroidApplication();
+
     @Override
     public void apply(Project project) {
-        AndroidApplication dslModel = project.getExtensions().create("androidApplication", AndroidApplication.class);
+        AndroidApplication dslModel = getAndroidApplication();
 
         // Register an afterEvaluate listener before we apply the Android plugin to ensure we can
         // run actions before Android does.

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/library/StandaloneAndroidLibraryPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/library/StandaloneAndroidLibraryPlugin.java
@@ -9,6 +9,7 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.experimental.common.LibraryDependencies;
+import org.gradle.api.internal.plugins.software.SoftwareType;
 import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension;
 
 import static org.gradle.api.experimental.android.AndroidDSLSupport.ifPresent;
@@ -18,9 +19,12 @@ import static org.gradle.api.experimental.android.AndroidDSLSupport.ifPresent;
  * and links the declarative model to the official plugin.
  */
 public abstract class StandaloneAndroidLibraryPlugin implements Plugin<Project> {
+    @SoftwareType(name = "androidLibrary", modelPublicType=AndroidLibrary.class)
+    abstract public AndroidLibrary getAndroidLibrary();
+
     @Override
     public void apply(Project project) {
-        AndroidLibrary dslModel = project.getExtensions().create("androidLibrary", AndroidLibrary.class);
+        AndroidLibrary dslModel = getAndroidLibrary();
 
         // Register an afterEvaluate listener before we apply the Android plugin to ensure we can
         // run actions before Android does.

--- a/unified-prototype/unified-plugin/plugin-jvm/build.gradle.kts
+++ b/unified-prototype/unified-plugin/plugin-jvm/build.gradle.kts
@@ -18,5 +18,9 @@ gradlePlugin {
             id = "org.gradle.experimental.java-application"
             implementationClass = "org.gradle.api.experimental.jvm.StandaloneJavaApplicationPlugin"
         }
+        create("jvm-ecosystem") {
+            id = "org.gradle.experimental.jvm-ecosystem"
+            implementationClass = "org.gradle.api.experimental.jvm.JvmEcosystemPlugin"
+        }
     }
 }

--- a/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/jvm/JvmEcosystemPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/jvm/JvmEcosystemPlugin.java
@@ -1,0 +1,17 @@
+package org.gradle.api.experimental.jvm;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.initialization.Settings;
+import org.gradle.api.internal.SettingsInternal;
+import org.gradle.plugin.software.internal.SoftwareTypeRegistry;
+
+public class JvmEcosystemPlugin implements Plugin<Settings> {
+    @Override
+    public void apply(Settings target) {
+        // To be replaced with static annotations once https://github.com/gradle/gradle/pull/28736 is merged
+        SettingsInternal settings = (SettingsInternal) target;
+        SoftwareTypeRegistry softwareTypeRegistry = settings.getServices().get(SoftwareTypeRegistry.class);
+        softwareTypeRegistry.register(StandaloneJavaApplicationPlugin.class);
+        softwareTypeRegistry.register(StandaloneJvmLibraryPlugin.class);
+    }
+}

--- a/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/jvm/StandaloneJavaApplicationPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/jvm/StandaloneJavaApplicationPlugin.java
@@ -2,6 +2,7 @@ package org.gradle.api.experimental.jvm;
 
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.internal.plugins.software.SoftwareType;
 import org.gradle.api.plugins.ApplicationPlugin;
 import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.jvm.toolchain.JavaLanguageVersion;
@@ -10,10 +11,13 @@ import org.gradle.jvm.toolchain.JavaLanguageVersion;
  * Creates a declarative {@link JavaApplication} DSL model, applies the official Java application plugin,
  * and links the declarative model to the official plugin.
  */
-public class StandaloneJavaApplicationPlugin implements Plugin<Project> {
+abstract public class StandaloneJavaApplicationPlugin implements Plugin<Project> {
+    @SoftwareType(name= "javaApplication", modelPublicType=JavaApplication.class)
+    abstract public JavaApplication getJavaApplication();
+
     @Override
     public void apply(Project project) {
-        JavaApplication dslModel = project.getExtensions().create("javaApplication", JavaApplication.class);
+        JavaApplication dslModel = getJavaApplication();
 
         project.getPlugins().apply(ApplicationPlugin.class);
 

--- a/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/jvm/StandaloneJvmLibraryPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/jvm/StandaloneJvmLibraryPlugin.java
@@ -3,6 +3,7 @@ package org.gradle.api.experimental.jvm;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.experimental.common.LibraryDependencies;
+import org.gradle.api.internal.plugins.software.SoftwareType;
 import org.gradle.api.plugins.JavaLibraryPlugin;
 import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.plugins.internal.JavaPluginHelper;
@@ -13,10 +14,13 @@ import org.gradle.api.tasks.compile.JavaCompile;
  * Creates a declarative {@link JvmLibrary} DSL model, applies the official Jvm plugin,
  * and links the declarative model to the official plugin.
  */
-public class StandaloneJvmLibraryPlugin implements Plugin<Project> {
+abstract public class StandaloneJvmLibraryPlugin implements Plugin<Project> {
+    @SoftwareType(name= "jvmLibrary", modelPublicType=JvmLibrary.class)
+    abstract public AbstractJvmLibrary getJvmLibrary();
+
     @Override
     public void apply(Project project) {
-        AbstractJvmLibrary dslModel = project.getExtensions().create("jvmLibrary", AbstractJvmLibrary.class);
+        AbstractJvmLibrary dslModel = getJvmLibrary();
 
         project.getPlugins().apply(JavaLibraryPlugin.class);
 

--- a/unified-prototype/unified-plugin/plugin-kmp/build.gradle.kts
+++ b/unified-prototype/unified-plugin/plugin-kmp/build.gradle.kts
@@ -15,5 +15,9 @@ gradlePlugin {
             id = "org.gradle.experimental.kmp-library"
             implementationClass = "org.gradle.api.experimental.kmp.StandaloneKmpLibraryPlugin"
         }
+        create("kmp-ecosystem") {
+            id = "org.gradle.experimental.kmp-ecosystem"
+            implementationClass = "org.gradle.api.experimental.kmp.KmpEcosystemPlugin"
+        }
     }
 }

--- a/unified-prototype/unified-plugin/plugin-kmp/src/main/java/org/gradle/api/experimental/kmp/KmpEcosystemPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-kmp/src/main/java/org/gradle/api/experimental/kmp/KmpEcosystemPlugin.java
@@ -1,0 +1,16 @@
+package org.gradle.api.experimental.kmp;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.initialization.Settings;
+import org.gradle.api.internal.SettingsInternal;
+import org.gradle.plugin.software.internal.SoftwareTypeRegistry;
+
+public class KmpEcosystemPlugin implements Plugin<Settings> {
+    @Override
+    public void apply(Settings target) {
+        // To be replaced with static annotations once https://github.com/gradle/gradle/pull/28736 is merged
+        SettingsInternal settings = (SettingsInternal) target;
+        SoftwareTypeRegistry softwareTypeRegistry = settings.getServices().get(SoftwareTypeRegistry.class);
+        softwareTypeRegistry.register(StandaloneKmpLibraryPlugin.class);
+    }
+}

--- a/unified-prototype/unified-plugin/plugin-kmp/src/main/java/org/gradle/api/experimental/kmp/StandaloneKmpLibraryPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-kmp/src/main/java/org/gradle/api/experimental/kmp/StandaloneKmpLibraryPlugin.java
@@ -5,6 +5,7 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.DependencyScopeConfiguration;
 import org.gradle.api.experimental.common.LibraryDependencies;
+import org.gradle.api.internal.plugins.software.SoftwareType;
 import org.gradle.api.provider.Property;
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget;
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension;
@@ -14,7 +15,10 @@ import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet;
  * Creates a declarative {@link KmpLibrary} DSL model, applies the official KMP plugin,
  * and links the declarative model to the official plugin.
  */
-public class StandaloneKmpLibraryPlugin implements Plugin<Project> {
+abstract public class StandaloneKmpLibraryPlugin implements Plugin<Project> {
+    @SoftwareType(name="kmpLibrary", modelPublicType=KmpLibrary.class)
+    abstract public AbstractKmpLibrary getKmpLibrary();
+
     @Override
     public void apply(Project project) {
         KmpLibrary dslModel = createDslModel(project);
@@ -30,7 +34,7 @@ public class StandaloneKmpLibraryPlugin implements Plugin<Project> {
     }
 
     private KmpLibrary createDslModel(Project project) {
-        KmpLibrary dslModel = project.getExtensions().create("kmpLibrary", AbstractKmpLibrary.class);
+        KmpLibrary dslModel = getKmpLibrary();
 
         // In order for function extraction from the DependencyCollector on the library deps to work, configurations must exist
         // Matching the names of the getters on LibraryDependencies


### PR DESCRIPTION
This converts all prototype plugins to use software types and eco system plugins that can be applied at the settings level.