### PR TITLE
Add publishing to unified-plugin plugins

### DIFF
--- a/unified-prototype/unified-plugin/build-logic/build.gradle.kts
+++ b/unified-prototype/unified-plugin/build-logic/build.gradle.kts
@@ -1,0 +1,8 @@
+plugins {
+    `kotlin-dsl`
+}
+
+dependencies {
+    implementation("com.gradle.publish:plugin-publish-plugin:1.2.1")
+    implementation("com.github.johnrengelman:shadow:8.1.1")
+}

--- a/unified-prototype/unified-plugin/build-logic/settings.gradle.kts
+++ b/unified-prototype/unified-plugin/build-logic/settings.gradle.kts
@@ -1,0 +1,9 @@
+dependencyResolutionManagement {
+    repositories {
+        google()
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "build-logic"

--- a/unified-prototype/unified-plugin/build-logic/src/main/kotlin/build-logic.publishing.gradle.kts
+++ b/unified-prototype/unified-plugin/build-logic/src/main/kotlin/build-logic.publishing.gradle.kts
@@ -1,0 +1,44 @@
+import java.util.regex.Matcher
+import java.util.regex.Pattern
+
+plugins {
+    id("com.gradle.plugin-publish")
+    id("com.github.johnrengelman.shadow") apply false
+    signing
+}
+
+val commonOnlyJarDependencyScope = configurations.dependencyScope("commonOnlyJarDependencyScope")
+val commonOnlyJar = configurations.resolvable("commonOnlyJar") {
+    extendsFrom(commonOnlyJarDependencyScope.get())
+}
+
+dependencies {
+    commonOnlyJarDependencyScope(project(":plugin-common")) {
+        isTransitive = false
+    }
+}
+
+tasks.shadowJar {
+    configurations = listOf(commonOnlyJar.get())
+    archiveClassifier.set("")
+    relocate(
+        "org.gradle.api.experimental.common",
+        Matcher.quoteReplacement("org.gradle.api.experimental.common.0shaded.into.${project.name}"),
+    )
+}
+
+gradlePlugin {
+    website = "https://github.com/gradle/declarative-gradle"
+    vcsUrl = "https://github.com/gradle/declarative-gradle"
+}
+
+signing {
+    useInMemoryPgpKeys(
+        project.providers.environmentVariable("PGP_SIGNING_KEY").orNull,
+        project.providers.environmentVariable("PGP_SIGNING_KEY_PASSPHRASE").orNull
+    )
+}
+
+gradle.taskGraph.whenReady {
+    signing.isRequired = allTasks.stream().anyMatch { it is com.gradle.publish.PublishTask }
+}

--- a/unified-prototype/unified-plugin/build.gradle.kts
+++ b/unified-prototype/unified-plugin/build.gradle.kts
@@ -4,5 +4,5 @@ plugins {
 
 subprojects {
     group = "org.gradle.experimental"
-    version = "0.1"
+    version = "0.1.0-SNAPSHOT"
 }

--- a/unified-prototype/unified-plugin/plugin-android/build.gradle.kts
+++ b/unified-prototype/unified-plugin/plugin-android/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     `kotlin-dsl`
+    id("build-logic.publishing")
 }
 
 description = "Implements the declarative Android DSL prototype"
@@ -15,14 +16,17 @@ gradlePlugin {
         create("android-library-plugin") {
             id = "org.gradle.experimental.android-library"
             implementationClass = "org.gradle.api.experimental.android.library.StandaloneAndroidLibraryPlugin"
+            tags = setOf("declarative-gradle", "android")
         }
         create("android-application-plugin") {
             id = "org.gradle.experimental.android-application"
             implementationClass = "org.gradle.api.experimental.android.application.StandaloneAndroidApplicationPlugin"
+            tags = setOf("declarative-gradle", "android")
         }
         create("android-ecosystem-plugin") {
             id = "org.gradle.experimental.android-ecosystem"
             implementationClass = "org.gradle.api.experimental.android.AndroidEcosystemPlugin"
+            tags = setOf("declarative-gradle", "android")
         }
     }
 }

--- a/unified-prototype/unified-plugin/plugin-jvm/build.gradle.kts
+++ b/unified-prototype/unified-plugin/plugin-jvm/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     `kotlin-dsl`
+    id("build-logic.publishing")
 }
 
 description = "Implements the declarative JVM DSL prototype"
@@ -13,18 +14,22 @@ gradlePlugin {
         create("jvm-library") {
             id = "org.gradle.experimental.jvm-library"
             implementationClass = "org.gradle.api.experimental.jvm.StandaloneJvmLibraryPlugin"
+            tags = setOf("declarative-gradle", "java", "jvm")
         }
         create("java-library") {
             id = "org.gradle.experimental.java-library"
             implementationClass = "org.gradle.api.experimental.java.StandaloneJavaLibraryPlugin"
+            tags = setOf("declarative-gradle", "java", "jvm")
         }
         create("java-application") {
             id = "org.gradle.experimental.java-application"
             implementationClass = "org.gradle.api.experimental.java.StandaloneJavaApplicationPlugin"
+            tags = setOf("declarative-gradle", "java", "jvm")
         }
         create("jvm-ecosystem") {
             id = "org.gradle.experimental.jvm-ecosystem"
             implementationClass = "org.gradle.api.experimental.jvm.JvmEcosystemPlugin"
+            tags = setOf("declarative-gradle", "java", "jvm")
         }
     }
 }

--- a/unified-prototype/unified-plugin/plugin-kmp/build.gradle.kts
+++ b/unified-prototype/unified-plugin/plugin-kmp/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     `kotlin-dsl`
+    id("build-logic.publishing")
 }
 
 description = "Implements the declarative KMP DSL prototype"
@@ -14,10 +15,12 @@ gradlePlugin {
         create("kmp-plugin") {
             id = "org.gradle.experimental.kmp-library"
             implementationClass = "org.gradle.api.experimental.kmp.StandaloneKmpLibraryPlugin"
+            tags = setOf("declarative-gradle", "kotlin-multiplatform")
         }
         create("kmp-ecosystem") {
             id = "org.gradle.experimental.kmp-ecosystem"
             implementationClass = "org.gradle.api.experimental.kmp.KmpEcosystemPlugin"
+            tags = setOf("declarative-gradle", "kotlin-multiplatform")
         }
     }
 }

--- a/unified-prototype/unified-plugin/settings.gradle.kts
+++ b/unified-prototype/unified-plugin/settings.gradle.kts
@@ -6,6 +6,7 @@ dependencyResolutionManagement {
     }
 }
 
+includeBuild("build-logic")
 include("plugin-android")
 include("plugin-jvm")
 include("plugin-kmp")


### PR DESCRIPTION
- Added tags to each plugin, using common `declarative-gradle` tag for easy discoverability
- Version changed to 0.1.0-SNAPSHOT to allow for snapshot publishing separate from a dedicates release
- Shaded plugin-common into each plugin separately, since it would need a different publishing setup if it were not
  - I'm open to setting up different publishing, but I'm not sure where it would go / if we have any existing setup I could copy for this