### PR TITLE
Change software type registration to use static annotations

### DIFF
--- a/unified-prototype/gradle/wrapper/gradle-wrapper.properties
+++ b/unified-prototype/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-8.9-20240410113234+0000-bin.zip
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-8.9-20240415150249+0000-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/AndroidEcosystemPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/AndroidEcosystemPlugin.java
@@ -5,16 +5,12 @@ import org.gradle.api.experimental.android.application.StandaloneAndroidApplicat
 import org.gradle.api.experimental.android.library.StandaloneAndroidLibraryPlugin;
 import org.gradle.api.initialization.Settings;
 import org.gradle.api.internal.SettingsInternal;
+import org.gradle.api.internal.plugins.software.RegistersSoftwareTypes;
 import org.gradle.plugin.software.internal.SoftwareTypeRegistry;
 
+@RegistersSoftwareTypes({StandaloneAndroidApplicationPlugin.class, StandaloneAndroidLibraryPlugin.class})
 public class AndroidEcosystemPlugin implements Plugin<Settings> {
 
     @Override
-    public void apply(Settings target) {
-        // To be replaced with static annotations once https://github.com/gradle/gradle/pull/28736 is merged
-        SettingsInternal settings = (SettingsInternal) target;
-        SoftwareTypeRegistry softwareTypeRegistry = settings.getServices().get(SoftwareTypeRegistry.class);
-        softwareTypeRegistry.register(StandaloneAndroidApplicationPlugin.class);
-        softwareTypeRegistry.register(StandaloneAndroidLibraryPlugin.class);
-    }
+    public void apply(Settings target) { }
 }

--- a/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/jvm/JvmEcosystemPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/jvm/JvmEcosystemPlugin.java
@@ -5,16 +5,11 @@ import org.gradle.api.experimental.java.StandaloneJavaApplicationPlugin;
 import org.gradle.api.experimental.java.StandaloneJavaLibraryPlugin;
 import org.gradle.api.initialization.Settings;
 import org.gradle.api.internal.SettingsInternal;
+import org.gradle.api.internal.plugins.software.RegistersSoftwareTypes;
 import org.gradle.plugin.software.internal.SoftwareTypeRegistry;
 
+@RegistersSoftwareTypes({StandaloneJavaApplicationPlugin.class, StandaloneJavaLibraryPlugin.class, StandaloneJvmLibraryPlugin.class})
 public class JvmEcosystemPlugin implements Plugin<Settings> {
     @Override
-    public void apply(Settings target) {
-        // To be replaced with static annotations once https://github.com/gradle/gradle/pull/28736 is merged
-        SettingsInternal settings = (SettingsInternal) target;
-        SoftwareTypeRegistry softwareTypeRegistry = settings.getServices().get(SoftwareTypeRegistry.class);
-        softwareTypeRegistry.register(StandaloneJavaApplicationPlugin.class);
-        softwareTypeRegistry.register(StandaloneJavaLibraryPlugin.class);
-        softwareTypeRegistry.register(StandaloneJvmLibraryPlugin.class);
-    }
+    public void apply(Settings target) { }
 }

--- a/unified-prototype/unified-plugin/plugin-kmp/src/main/java/org/gradle/api/experimental/kmp/KmpEcosystemPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-kmp/src/main/java/org/gradle/api/experimental/kmp/KmpEcosystemPlugin.java
@@ -3,14 +3,12 @@ package org.gradle.api.experimental.kmp;
 import org.gradle.api.Plugin;
 import org.gradle.api.initialization.Settings;
 import org.gradle.api.internal.SettingsInternal;
+import org.gradle.api.internal.plugins.software.RegistersSoftwareTypes;
 import org.gradle.plugin.software.internal.SoftwareTypeRegistry;
 
+
+@RegistersSoftwareTypes(StandaloneKmpLibraryPlugin.class)
 public class KmpEcosystemPlugin implements Plugin<Settings> {
     @Override
-    public void apply(Settings target) {
-        // To be replaced with static annotations once https://github.com/gradle/gradle/pull/28736 is merged
-        SettingsInternal settings = (SettingsInternal) target;
-        SoftwareTypeRegistry softwareTypeRegistry = settings.getServices().get(SoftwareTypeRegistry.class);
-        softwareTypeRegistry.register(StandaloneKmpLibraryPlugin.class);
-    }
+    public void apply(Settings target) { }
 }


### PR DESCRIPTION
Software type registration is now done with `@RegistersSoftwareTypes` annotations.