### PR TITLE
Demo object-based conventions in Now In Android

### DIFF
--- a/unified-prototype/gradle/wrapper/gradle-wrapper.properties
+++ b/unified-prototype/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-8.9-20240424122219+0000-bin.zip
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-8.9-branch-gh_declarative_dependencies_conventions-20240514203210+0000-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/library/AndroidLibrary.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/library/AndroidLibrary.java
@@ -24,6 +24,7 @@ import org.gradle.api.experimental.android.nia.Feature;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Nested;
 import org.gradle.declarative.dsl.model.annotations.Configuring;
+import org.gradle.declarative.dsl.model.annotations.NestedRestricted;
 import org.gradle.declarative.dsl.model.annotations.Restricted;
 
 @Restricted
@@ -66,7 +67,7 @@ public interface AndroidLibrary {
         kotlinSerialization.getEnabled().set(true);
     }
 
-    @Nested
+    @NestedRestricted
     AndroidLibraryDependencies getDependencies();
 
     @Configuring

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/library/StandaloneAndroidLibraryPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/library/StandaloneAndroidLibraryPlugin.java
@@ -29,7 +29,7 @@ public abstract class StandaloneAndroidLibraryPlugin implements Plugin<Project> 
         AndroidLibrary dslModel = getAndroidLibrary();
 
         // Setup Android Library conventions
-        dslModel.getJdkVersion().convention(DEFAULT_SDKS.JDK);
+        // dslModel.getJdkVersion().convention(DEFAULT_SDKS.JDK); // Set by NiA convention now
         dslModel.getCompileSdk().convention(DEFAULT_SDKS.TARGET_ANDROID_SDK);
         dslModel.getMinSdk().convention(DEFAULT_SDKS.MIN_ANDROID_SDK); // https://developer.android.com/build/multidex#mdex-gradle
         dslModel.getKotlinSerialization().getEnabled().convention(false);

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/nia/NiaSupport.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/nia/NiaSupport.java
@@ -36,7 +36,7 @@ public class NiaSupport {
         LibraryExtension androidLib = project.getExtensions().getByType(LibraryExtension.class);
         LibraryAndroidComponentsExtension androidLibComponents = project.getExtensions().getByType(LibraryAndroidComponentsExtension.class);
 
-        dslModel.getDependencies().getImplementation().add("androidx.tracing:tracing-ktx:1.3.0-alpha02");
+        // dslModel.getDependencies().getImplementation().add("androidx.tracing:tracing-ktx:1.3.0-alpha02"); // Set by convention
         dslModel.getDependencies().getCoreLibraryDesugaring().add("com.android.tools:desugar_jdk_libs:2.0.4");
 
         setTargetSdk(androidLib);
@@ -45,7 +45,6 @@ public class NiaSupport {
         configureKotlin(project);
 
         dslModel.getDependencies().getTestImplementation().add("org.jetbrains.kotlin:kotlin-test");
-        dslModel.getDependencies().getImplementation().add("androidx.tracing:tracing-ktx:1.3.0-alpha02");
 
         disableUnnecessaryAndroidTests(project, androidLibComponents);
 


### PR DESCRIPTION
Update to Gradle branch with support for conventions
- Update libs to support conventions on dependencies, remove duplicate dep declaration in plugin.
- Remove dep declaration from plugin code (it will be added to a project convention in NiA).
- Remove JDK convention from plugin code.