### PR TITLE
Don't expose coreDesugaring conf

### DIFF
--- a/unified-prototype/testbed-android-application/build.gradle.dcl
+++ b/unified-prototype/testbed-android-application/build.gradle.dcl
@@ -10,7 +10,6 @@ androidApplication {
     dependencies {
         implementation("com.google.guava:guava:32.1.3-jre")
         implementation(project(":android-util"))
-        coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
     }
 
     buildTypes {

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/application/AndroidApplication.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/application/AndroidApplication.java
@@ -20,6 +20,7 @@ import com.android.build.api.dsl.ApplicationBaseFlavor;
 import com.android.build.api.dsl.BaseFlavor;
 import com.android.build.api.dsl.CommonExtension;
 import org.gradle.api.Action;
+import org.gradle.api.experimental.android.library.CoreLibraryDesugaring;
 import org.gradle.api.experimental.common.ApplicationDependencies;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Nested;
@@ -87,5 +88,15 @@ public interface AndroidApplication {
     @Configuring
     default void buildTypes(Action<? super AndroidApplicationBuildTypes> action) {
         action.execute(getBuildTypes());
+    }
+
+    @Nested
+    CoreLibraryDesugaring getCoreLibraryDesugaring();
+
+    @Configuring
+    default void coreLibraryDesugaring(Action<? super CoreLibraryDesugaring> action) {
+        CoreLibraryDesugaring coreLibraryDesugaring = getCoreLibraryDesugaring();
+        action.execute(coreLibraryDesugaring);
+        coreLibraryDesugaring.getEnabled().set(true);
     }
 }

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/application/AndroidApplicationDependencies.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/application/AndroidApplicationDependencies.java
@@ -16,12 +16,9 @@
 
 package org.gradle.api.experimental.android.application;
 
-import org.gradle.api.artifacts.dsl.DependencyCollector;
 import org.gradle.api.experimental.common.ApplicationDependencies;
 import org.gradle.declarative.dsl.model.annotations.Restricted;
 
-@SuppressWarnings("UnstableApiUsage")
 @Restricted
 public interface AndroidApplicationDependencies extends ApplicationDependencies {
-    DependencyCollector getCoreLibraryDesugaring();
 }

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/library/AndroidLibrary.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/library/AndroidLibrary.java
@@ -109,4 +109,14 @@ public interface AndroidLibrary {
         action.execute(compose);
         compose.getEnabled().set(true);
     }
+
+    @Nested
+    CoreLibraryDesugaring getCoreLibraryDesugaring();
+
+    @Configuring
+    default void coreLibraryDesugaring(Action<? super CoreLibraryDesugaring> action) {
+        CoreLibraryDesugaring coreLibraryDesugaring = getCoreLibraryDesugaring();
+        action.execute(coreLibraryDesugaring);
+        coreLibraryDesugaring.getEnabled().set(true);
+    }
 }

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/library/AndroidLibraryDependencies.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/library/AndroidLibraryDependencies.java
@@ -24,5 +24,4 @@ import org.gradle.declarative.dsl.model.annotations.Restricted;
 @Restricted
 public interface AndroidLibraryDependencies extends LibraryDependencies {
     DependencyCollector getKsp();
-    DependencyCollector getCoreLibraryDesugaring();
 }

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/library/CoreLibraryDesugaring.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/library/CoreLibraryDesugaring.java
@@ -1,0 +1,19 @@
+package org.gradle.api.experimental.android.library;
+
+import org.gradle.api.provider.Property;
+import org.gradle.declarative.dsl.model.annotations.Restricted;
+
+@Restricted
+public interface CoreLibraryDesugaring {
+    /**
+     * Can be enabled manually, or automatically when the TargetJavaVersion is set to 8 or higher.
+     */
+    @Restricted
+    Property<Boolean> getEnabled();
+
+    /**
+     * The version of the library to use for desugaring.
+     */
+    @Restricted
+    Property<String> getLibVersion();
+}

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/nia/NiaSupport.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/nia/NiaSupport.java
@@ -37,7 +37,6 @@ public class NiaSupport {
         LibraryAndroidComponentsExtension androidLibComponents = project.getExtensions().getByType(LibraryAndroidComponentsExtension.class);
 
         dslModel.getDependencies().getImplementation().add("androidx.tracing:tracing-ktx:1.3.0-alpha02");
-        dslModel.getDependencies().getCoreLibraryDesugaring().add("com.android.tools:desugar_jdk_libs:2.0.4");
 
         setTargetSdk(androidLib);
         androidLib.setResourcePrefix(buildResourcePrefix(project));


### PR DESCRIPTION
- Auto-configure this if JDK > 8.
- Allow setting version of desugaring lib in new extension.
- Move to main Android lib/app from NiA-specific code.