### PR TITLE
Remove the need to shade plugin-common

### DIFF
--- a/unified-prototype/unified-plugin/build-logic/build.gradle.kts
+++ b/unified-prototype/unified-plugin/build-logic/build.gradle.kts
@@ -4,5 +4,4 @@ plugins {
 
 dependencies {
     implementation("com.gradle.publish:plugin-publish-plugin:1.2.1")
-    implementation("com.github.johnrengelman:shadow:8.1.1")
 }

--- a/unified-prototype/unified-plugin/build-logic/src/main/kotlin/build-logic.publishing.gradle.kts
+++ b/unified-prototype/unified-plugin/build-logic/src/main/kotlin/build-logic.publishing.gradle.kts
@@ -1,29 +1,6 @@
-import java.util.regex.Matcher
-
 plugins {
     id("com.gradle.plugin-publish")
-    id("com.github.johnrengelman.shadow") apply false
     signing
-}
-
-val commonOnlyJarDependencyScope = configurations.dependencyScope("commonOnlyJarDependencyScope")
-val commonOnlyJar = configurations.resolvable("commonOnlyJar") {
-    extendsFrom(commonOnlyJarDependencyScope.get())
-}
-
-dependencies {
-    commonOnlyJarDependencyScope(project(":plugin-common")) {
-        isTransitive = false
-    }
-}
-
-tasks.shadowJar {
-    configurations = listOf(commonOnlyJar.get())
-    archiveClassifier.set("")
-    relocate(
-        "org.gradle.api.experimental.common",
-        Matcher.quoteReplacement("org.gradle.api.experimental.common.0shaded.into.${project.name}"),
-    )
 }
 
 gradlePlugin {

--- a/unified-prototype/unified-plugin/plugin-common/build.gradle.kts
+++ b/unified-prototype/unified-plugin/plugin-common/build.gradle.kts
@@ -1,9 +1,22 @@
 plugins {
-    kotlin("jvm")
+    `kotlin-dsl`
+    id("build-logic.publishing")
 }
+
+description = "Common APIs and implementation classes shared by the Android, JVM, and KMP declarative prototypes"
 
 dependencies {
     implementation(gradleApi())
 }
 
-description = "Common APIs and implementation classes shared by the Android, JVM, and KMP declarative prototypes"
+gradlePlugin {
+    plugins {
+        create("common") {
+            id = "org.gradle.experimental.declarative-common"
+            displayName = "Common Experimental Declarative Plugin"
+            description = "Experimental declarative plugin containing common code shared by the Android, JVM, and KMP prototype plugins"
+            implementationClass = "org.gradle.api.experimental.common.CommonPlugin"
+            tags = setOf("declarative-gradle")
+        }
+    }
+}

--- a/unified-prototype/unified-plugin/plugin-common/src/main/java/org/gradle/api/experimental/common/CommonPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-common/src/main/java/org/gradle/api/experimental/common/CommonPlugin.java
@@ -1,0 +1,12 @@
+package org.gradle.api.experimental.common;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.initialization.Settings;
+
+public class CommonPlugin implements Plugin<Settings> {
+    @Override
+    public void apply(Settings target) {
+        // Currently does nothing, as this plugin is only used for its classes.
+        // In fact, no other plugin applies this one.
+    }
+}


### PR DESCRIPTION
Gives it a dummy plugin class that nothing applies, and publishes it to the plugin portal