### PR TITLE
Add CD pipeline for the Declarative Gradle subsite

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -51,15 +51,6 @@ jobs:
           name: github-pages
           path: "_site/"
 
-      - name: Build the docs site for gradle.org
-        run: mkdocs build -f mkdocs-dotorg.yml
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
-        with:
-          name: dotorg-site
-          path: "_dotorg_site/"
-
   # Deployment job
   deploy:
     environment:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,73 @@
+name: Deploy to GitHub Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main", "site-cd"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: "true"
+      
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v3
+      
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+   
+      - name: Install dependencies
+        run: pip install -r .devcontainer/requirements.txt
+  
+      - name: Build the docs site
+        run: mkdocs build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          name: github-pages
+          path: "_site/"
+
+      - name: Build the docs site for gradle.org
+        run: mkdocs build -f mkdocs-dotorg.yml
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          name: dotorg-site
+          path: "_dotorg_site/"
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2


### PR DESCRIPTION
I am not sure whether we need it or whether we will proceed with deployments to gradle.org, but staging it for preview/feedback

Preview: https://oleg-nenashev.github.io/declarative-gradle/
