### PR TITLE
Improve conventions for JVM software types and CLI application software types

### DIFF
--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -30,16 +30,17 @@ To get started, follow the steps in [this guide](../android/README.md#3-getting-
 
 At the moment, we do not have a detailed guide for other project types.
 They are coming soon.
-For now, you can check out the [Declarative Gradle prototypes](../../early-prototypes/README.md).
+For now, you can check out the [Declarative Gradle prototypes](../../unified-prototypes/README.md).
 They include samples and built-in documentation so that you can try them out.
 It might be too early to adopt them in your projects due to the upcoming compatibility breaking changes,
-but your're welcome to try Declarative Gradle in non-production projects and experimental branches.
+but you're welcome to try Declarative Gradle in non-production projects and experimental branches.
 
 - [Declarative Gradle for Java](../../unified-prototype/README.md#java)
-- [Declarative Gradle for Kotlin](../../unified-prototype/README.md#kotlin-jvm)
+- [Declarative Gradle for Kotlin JVM](../../unified-prototype/README.md#kotlin-jvm)
 - [Declarative Gradle for Kotlin Multiplatform (KMP)](../../unified-prototype/README.md#kotlin-kmp)
+- [Declarative Gradle for Swift](../../unified-prototype/README.md#swift)
 
 ## References
 
 - [Support for Android](../android/README.md)
-- [Other Declarative Gradle prototypes](../../early-prototypes/README.md)
+- [Other Declarative Gradle prototypes](../../unified-prototypes/README.md)

--- a/docs/java/README.md
+++ b/docs/java/README.md
@@ -37,3 +37,4 @@ javaApplication {
 
 - [Declarative Gradle for Kotlin](../kotlin/README.md)
 - [Declarative Gradle for Android](../android/README.md)
+- [Declarative Gradle for Swift](../swift/README.md)

--- a/docs/kotlin/README.md
+++ b/docs/kotlin/README.md
@@ -1,22 +1,24 @@
 ---
 title: Declarative Gradle for Kotlin
 description: >
-  Declarative Gradle has solution for Kotlin projects, libraries and
-  also for Kotlin Multiplatform applications.
+  Declarative Gradle has solution for Kotlin application and libraries
 ---
 
-Declarative Gradle has solution for Kotlin projects, libraries and
-also for Kotlin Multiplatform (KMP) applications.
+Declarative Gradle has solution for Kotlin JVM application and libraries and
+also for Kotlin Multiplatform (KMP) applications and libraries.
 
 > **DISCLAIMER:** This page is under development, more content will be added soon.
 > For now, check out the prototypes referenced below.
 
 ## Prototypes
 
-- [Kotlin Application](../../unified-prototype/testbed-kotlin-application/)
-- [Kotlin Library](../../unified-prototype/testbed-kotlin-library/)
+- [Kotlin JVM Application](../../unified-prototype/testbed-kotlin-jvm-application/)
+- [Kotlin JVM Library](../../unified-prototype/testbed-kotlin-jvm-library/)
+- [Kotlin Multiplatform Application](../../unified-prototype/testbed-kotlin-application/)
+- [Kotlin Multiplatform Library](../../unified-prototype/testbed-kotlin-library/)
 
 ## References
 
 - [Declarative Gradle for Java](../java/README.md)
 - [Declarative Gradle for Android](../android/README.md)
+- [Declarative Gradle for Swift](../swift/README.md)

--- a/docs/swift/README.md
+++ b/docs/swift/README.md
@@ -1,0 +1,21 @@
+---
+title: Declarative Gradle for Swift
+description: >
+  Declarative Gradle has solution for Swift
+---
+
+Declarative Gradle has solution for Swift applications and libraries.
+
+> **DISCLAIMER:** This page is under development, more content will be added soon.
+> For now, check out the prototypes referenced below.
+
+## Prototypes
+
+- [Swift Application](../../unified-prototype/testbed-swift-application/)
+- [Swift Library](../../unified-prototype/testbed-swift-library/)
+
+## References
+
+- [Declarative Gradle for Java](../java/README.md)
+- [Declarative Gradle for Kotlin](../kotlin/README.md)
+- [Declarative Gradle for Android](../android/README.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,6 +86,7 @@ nav:
       Declarative Gradle for Android: docs/android/README.md
       Declarative Gradle for Java/JVM: docs/java/README.md
       Declarative Gradle for Kotlin: docs/kotlin/README.md
+      Declarative Gradle for Swift: docs/swift/README.md
       Public Roadmap: ROADMAP.md
   - Getting Started:
       Overview: docs/getting-started/README.md

--- a/unified-prototype/README.md
+++ b/unified-prototype/README.md
@@ -12,8 +12,8 @@ These samples show the definition of a simple Java application and library that 
 
 To run the application, use:
 
-```
-> ./gradlew testbed-java-application:run
+```shell
+> ./gradlew testbed-java-application:runAll
 ```
 
 ## JVM
@@ -24,8 +24,8 @@ These samples show the definition of a simple Java application and library that 
 
 To run the application, use:
 
-```
-> ./gradlew testbed-java-application:run
+```shell
+> ./gradlew testbed-jvm-application:runAll
 ```
 
 ## Kotlin JVM
@@ -36,8 +36,8 @@ These samples show the definition of a simple Kotlin JVM application and library
 
 To run the application, use:
 
-```
-> ./gradlew testbed-kotlin-jvm-application:run
+```shell
+> ./gradlew testbed-kotlin-jvm-application:runAll
 ```
 
 ## Kotlin Multiplatform
@@ -48,25 +48,16 @@ The `unified-prototype/plugin-kmp` plugin demonstrates creating extensions using
 
 The sample project demonstrates setting properties, using a common dependencies block, and adding dependencies to specific targets.
 
-### Implementation Notes
-
-An Apache Commons dependency is used by the JVM code.
-A SQLDelight dependency is used by the JS code.
-The kotlinx.datetime multiplatform dep is used by common code.
-
-The `StandaloneKmpLibraryPlugin` plugin works by using `project.afterEvaluate` to load data from the Declarative DSL extensions into KGP's model.
-
 ### Limitations
 
 The KMP example is currently limited, and does not support any targets other than `nodeJs`, `jvm` and `macOsArm64`.
 
 ### Running
 
-From the `testbed-kotlin-application` directory, run `jvmRun` using the Gradle wrapper in the parent directory:
+To run the application, use:
 
 ```shell
-cd testbed-kotlin-application
-../gradlew jvmRun
+../gradlew testbed-kotlin-application:runAll
 ```
 
 ### Building
@@ -134,3 +125,9 @@ gradlew :testbed-android-application:assembleRelease
 ## Swift
 
 The sample Swift projects live in the `testbed-swift-library` and `testbed-swift-application` directories.
+
+To run the application, use:
+
+```shell
+../gradlew testbed-swift-application:runAll
+```

--- a/unified-prototype/settings.gradle.dcl
+++ b/unified-prototype/settings.gradle.dcl
@@ -14,13 +14,6 @@ plugins {
     id("org.gradle.experimental.swift-ecosystem")
 }
 
-dependencyResolutionManagement {
-    repositories {
-        mavenCentral()
-        google()
-    }
-}
-
 // Not currently supported by declarative model
 //rootProject.name = "unified-prototype"
 

--- a/unified-prototype/unified-plugin/plugin-android/build.gradle.kts
+++ b/unified-prototype/unified-plugin/plugin-android/build.gradle.kts
@@ -10,6 +10,7 @@ dependencies {
     api(libs.android.agp.application)
     api(libs.android.kotlin.android)
 
+    implementation(project(":plugin-jvm"))
     implementation(libs.ksp.plugin)
     implementation(libs.hilt.android.plugin)
     implementation(libs.kotlin.serialization.plugin)

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/AndroidEcosystemPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/AndroidEcosystemPlugin.java
@@ -3,6 +3,7 @@ package org.gradle.api.experimental.android;
 import org.gradle.api.Plugin;
 import org.gradle.api.experimental.android.application.StandaloneAndroidApplicationPlugin;
 import org.gradle.api.experimental.android.library.StandaloneAndroidLibraryPlugin;
+import org.gradle.api.experimental.jvm.JvmEcosystemConventionsPlugin;
 import org.gradle.api.initialization.Settings;
 import org.gradle.api.internal.plugins.software.RegistersSoftwareTypes;
 
@@ -10,5 +11,8 @@ import org.gradle.api.internal.plugins.software.RegistersSoftwareTypes;
 @RegistersSoftwareTypes({StandaloneAndroidApplicationPlugin.class, StandaloneAndroidLibraryPlugin.class})
 public abstract class AndroidEcosystemPlugin implements Plugin<Settings> {
     @Override
-    public void apply(Settings target) { }
+    public void apply(Settings target) {
+        target.getPlugins().apply(JvmEcosystemConventionsPlugin.class);
+        target.getDependencyResolutionManagement().getRepositories().google();
+    }
 }

--- a/unified-prototype/unified-plugin/plugin-common/src/main/java/org/gradle/api/experimental/common/CliApplicationConventionsPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-common/src/main/java/org/gradle/api/experimental/common/CliApplicationConventionsPlugin.java
@@ -1,0 +1,12 @@
+package org.gradle.api.experimental.common;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+
+public class CliApplicationConventionsPlugin implements Plugin<Project> {
+    @Override
+    public void apply(Project target) {
+        HasCliExecutables executables = target.getExtensions().getByType(HasCliExecutables.class);
+        target.getTasks().register("runAll", task -> task.dependsOn(executables.getRunTasks()));
+    }
+}

--- a/unified-prototype/unified-plugin/plugin-common/src/main/java/org/gradle/api/experimental/common/HasCliExecutables.java
+++ b/unified-prototype/unified-plugin/plugin-common/src/main/java/org/gradle/api/experimental/common/HasCliExecutables.java
@@ -1,0 +1,8 @@
+package org.gradle.api.experimental.common;
+
+import org.gradle.api.Task;
+import org.gradle.api.provider.ListProperty;
+
+public interface HasCliExecutables {
+    ListProperty<Task> getRunTasks();
+}

--- a/unified-prototype/unified-plugin/plugin-jvm/build.gradle.kts
+++ b/unified-prototype/unified-plugin/plugin-jvm/build.gradle.kts
@@ -7,6 +7,7 @@ description = "Implements the declarative JVM DSL prototype"
 
 dependencies {
     implementation(project(":plugin-common"))
+    implementation("org.gradle.toolchains:foojay-resolver:0.8.0")
 }
 
 gradlePlugin {

--- a/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/java/JavaApplication.java
+++ b/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/java/JavaApplication.java
@@ -1,5 +1,6 @@
 package org.gradle.api.experimental.java;
 
+import org.gradle.api.experimental.common.HasCliExecutables;
 import org.gradle.api.experimental.jvm.HasJavaTarget;
 import org.gradle.api.experimental.jvm.HasJvmApplication;
 import org.gradle.declarative.dsl.model.annotations.Restricted;
@@ -8,5 +9,5 @@ import org.gradle.declarative.dsl.model.annotations.Restricted;
  * An application implemented using a single version of Java.
  */
 @Restricted
-public interface JavaApplication extends HasJavaTarget, HasJvmApplication {
+public interface JavaApplication extends HasJavaTarget, HasJvmApplication, HasCliExecutables {
 }

--- a/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/java/StandaloneJavaApplicationPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/java/StandaloneJavaApplicationPlugin.java
@@ -2,6 +2,7 @@ package org.gradle.api.experimental.java;
 
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.experimental.common.CliApplicationConventionsPlugin;
 import org.gradle.api.experimental.jvm.internal.JvmPluginSupport;
 import org.gradle.api.internal.plugins.software.SoftwareType;
 import org.gradle.api.plugins.ApplicationPlugin;
@@ -19,6 +20,7 @@ abstract public class StandaloneJavaApplicationPlugin implements Plugin<Project>
         JavaApplication dslModel = getApplication();
 
         project.getPlugins().apply(ApplicationPlugin.class);
+        project.getPlugins().apply(CliApplicationConventionsPlugin.class);
 
         linkDslModelToPlugin(project, dslModel);
     }
@@ -27,5 +29,7 @@ abstract public class StandaloneJavaApplicationPlugin implements Plugin<Project>
         JvmPluginSupport.linkJavaVersion(project, dslModel);
         JvmPluginSupport.linkApplicationMainClass(project, dslModel);
         JvmPluginSupport.linkMainSourceSourceSetDependencies(project, dslModel.getDependencies());
+
+        dslModel.getRunTasks().add(project.getTasks().named("run"));
     }
 }

--- a/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/jvm/JvmApplication.java
+++ b/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/jvm/JvmApplication.java
@@ -1,7 +1,9 @@
 package org.gradle.api.experimental.jvm;
 
+import org.gradle.api.experimental.common.HasCliExecutables;
+
 /**
  * An application that runs on the JVM and that is implemented using one or more versions of Java.
  */
-public interface JvmApplication extends HasJavaTargets, HasJvmApplication {
+public interface JvmApplication extends HasJavaTargets, HasJvmApplication, HasCliExecutables {
 }

--- a/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/jvm/JvmEcosystemConventionsPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/jvm/JvmEcosystemConventionsPlugin.java
@@ -1,0 +1,18 @@
+package org.gradle.api.experimental.jvm;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.initialization.Settings;
+
+/**
+ * Applies some common conventions for the JVM ecosystems. In particular:
+ * <p>
+ * - Adds repository for Java toolchains.
+ * - Adds Maven central for JVM libraries.
+ */
+public class JvmEcosystemConventionsPlugin implements Plugin<Settings> {
+    @Override
+    public void apply(Settings target) {
+        target.getPlugins().apply("org.gradle.toolchains.foojay-resolver-convention");
+        target.getDependencyResolutionManagement().getRepositories().mavenCentral();
+    }
+}

--- a/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/jvm/JvmEcosystemPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/jvm/JvmEcosystemPlugin.java
@@ -4,9 +4,7 @@ import org.gradle.api.Plugin;
 import org.gradle.api.experimental.java.StandaloneJavaApplicationPlugin;
 import org.gradle.api.experimental.java.StandaloneJavaLibraryPlugin;
 import org.gradle.api.initialization.Settings;
-import org.gradle.api.internal.SettingsInternal;
 import org.gradle.api.internal.plugins.software.RegistersSoftwareTypes;
-import org.gradle.plugin.software.internal.SoftwareTypeRegistry;
 
 @RegistersSoftwareTypes({
         StandaloneJavaApplicationPlugin.class,
@@ -16,5 +14,7 @@ import org.gradle.plugin.software.internal.SoftwareTypeRegistry;
 })
 public class JvmEcosystemPlugin implements Plugin<Settings> {
     @Override
-    public void apply(Settings target) { }
+    public void apply(Settings target) {
+        target.getPlugins().apply(JvmEcosystemConventionsPlugin.class);
+    }
 }

--- a/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/jvm/StandaloneJvmApplicationPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/jvm/StandaloneJvmApplicationPlugin.java
@@ -2,10 +2,13 @@ package org.gradle.api.experimental.jvm;
 
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.experimental.common.CliApplicationConventionsPlugin;
 import org.gradle.api.experimental.jvm.internal.JvmPluginSupport;
 import org.gradle.api.internal.plugins.software.SoftwareType;
 import org.gradle.api.plugins.ApplicationPlugin;
+import org.gradle.api.tasks.JavaExec;
 import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.TaskProvider;
 import org.gradle.jvm.toolchain.JavaToolchainService;
 
 import javax.inject.Inject;
@@ -23,6 +26,7 @@ abstract public class StandaloneJvmApplicationPlugin implements Plugin<Project> 
         JvmApplication dslModel = getJvmApplication();
 
         project.getPlugins().apply(ApplicationPlugin.class);
+        project.getPlugins().apply(CliApplicationConventionsPlugin.class);
 
         linkDslModelToPlugin(project, dslModel);
     }
@@ -41,6 +45,13 @@ abstract public class StandaloneJvmApplicationPlugin implements Plugin<Project> 
 
             // Link dependencies to DSL
             JvmPluginSupport.linkSourceSetToDependencies(project, sourceSet, target.getDependencies());
+
+            // Create a run task
+            TaskProvider<JavaExec> runTask = project.getTasks().register(sourceSet.getTaskName("run", null), JavaExec.class, task -> {
+                task.getMainClass().set(dslModel.getMainClass());
+                task.setClasspath(sourceSet.getRuntimeClasspath());
+            });
+            dslModel.getRunTasks().add(runTask);
         });
     }
 }

--- a/unified-prototype/unified-plugin/plugin-kmp/src/main/java/org/gradle/api/experimental/kmp/KmpApplication.java
+++ b/unified-prototype/unified-plugin/plugin-kmp/src/main/java/org/gradle/api/experimental/kmp/KmpApplication.java
@@ -2,6 +2,7 @@ package org.gradle.api.experimental.kmp;
 
 import org.gradle.api.Action;
 import org.gradle.api.experimental.common.HasApplicationDependencies;
+import org.gradle.api.experimental.common.HasCliExecutables;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Nested;
@@ -12,7 +13,7 @@ import org.gradle.declarative.dsl.model.annotations.Restricted;
  * The public DSL interface for a declarative KMP application.
  */
 @Restricted
-public interface KmpApplication extends HasApplicationDependencies {
+public interface KmpApplication extends HasApplicationDependencies, HasCliExecutables {
     @Input
     Property<String> getLanguageVersion();
 

--- a/unified-prototype/unified-plugin/plugin-kmp/src/main/java/org/gradle/api/experimental/kmp/KmpEcosystemPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-kmp/src/main/java/org/gradle/api/experimental/kmp/KmpEcosystemPlugin.java
@@ -1,6 +1,7 @@
 package org.gradle.api.experimental.kmp;
 
 import org.gradle.api.Plugin;
+import org.gradle.api.experimental.jvm.JvmEcosystemConventionsPlugin;
 import org.gradle.api.experimental.kotlin.StandaloneKotlinJvmApplicationPlugin;
 import org.gradle.api.experimental.kotlin.StandaloneKotlinJvmLibraryPlugin;
 import org.gradle.api.initialization.Settings;
@@ -14,5 +15,7 @@ import org.gradle.api.internal.plugins.software.RegistersSoftwareTypes;
         StandaloneKotlinJvmApplicationPlugin.class})
 public class KmpEcosystemPlugin implements Plugin<Settings> {
     @Override
-    public void apply(Settings target) { }
+    public void apply(Settings target) {
+        target.getPlugins().apply(JvmEcosystemConventionsPlugin.class);
+    }
 }

--- a/unified-prototype/unified-plugin/plugin-kmp/src/main/java/org/gradle/api/experimental/kotlin/KotlinJvmApplication.java
+++ b/unified-prototype/unified-plugin/plugin-kmp/src/main/java/org/gradle/api/experimental/kotlin/KotlinJvmApplication.java
@@ -1,5 +1,6 @@
 package org.gradle.api.experimental.kotlin;
 
+import org.gradle.api.experimental.common.HasCliExecutables;
 import org.gradle.api.experimental.jvm.HasJavaTarget;
 import org.gradle.api.experimental.jvm.HasJvmApplication;
 import org.gradle.declarative.dsl.model.annotations.Restricted;
@@ -8,5 +9,5 @@ import org.gradle.declarative.dsl.model.annotations.Restricted;
  * An application implemented using Kotlin and that targets a single JVM version.
  */
 @Restricted
-public interface KotlinJvmApplication extends HasJavaTarget, HasJvmApplication {
+public interface KotlinJvmApplication extends HasJavaTarget, HasJvmApplication, HasCliExecutables {
 }

--- a/unified-prototype/unified-plugin/plugin-kmp/src/main/java/org/gradle/api/experimental/kotlin/StandaloneKotlinJvmApplicationPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-kmp/src/main/java/org/gradle/api/experimental/kotlin/StandaloneKotlinJvmApplicationPlugin.java
@@ -2,6 +2,7 @@ package org.gradle.api.experimental.kotlin;
 
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.experimental.common.CliApplicationConventionsPlugin;
 import org.gradle.api.experimental.jvm.internal.JvmPluginSupport;
 import org.gradle.api.experimental.kmp.internal.KotlinPluginSupport;
 import org.gradle.api.internal.plugins.software.SoftwareType;
@@ -21,6 +22,7 @@ abstract public class StandaloneKotlinJvmApplicationPlugin implements Plugin<Pro
 
         project.getPlugins().apply(ApplicationPlugin.class);
         project.getPlugins().apply("org.jetbrains.kotlin.jvm");
+        project.getPlugins().apply(CliApplicationConventionsPlugin.class);
 
         linkDslModelToPlugin(project, dslModel);
     }
@@ -29,5 +31,7 @@ abstract public class StandaloneKotlinJvmApplicationPlugin implements Plugin<Pro
         KotlinPluginSupport.linkJavaVersion(project, dslModel);
         JvmPluginSupport.linkApplicationMainClass(project, dslModel);
         JvmPluginSupport.linkMainSourceSourceSetDependencies(project, dslModel.getDependencies());
+
+        dslModel.getRunTasks().add(project.getTasks().named("run"));
     }
 }

--- a/unified-prototype/unified-plugin/plugin-swift/src/main/java/org/gradle/api/experimental/swift/StandaloneSwiftApplicationPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-swift/src/main/java/org/gradle/api/experimental/swift/StandaloneSwiftApplicationPlugin.java
@@ -2,10 +2,18 @@ package org.gradle.api.experimental.swift;
 
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.experimental.common.CliApplicationConventionsPlugin;
 import org.gradle.api.experimental.swift.internal.SwiftPluginSupport;
+import org.gradle.api.file.RegularFile;
 import org.gradle.api.internal.plugins.software.SoftwareType;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.Exec;
+import org.gradle.api.tasks.TaskProvider;
+import org.gradle.language.swift.SwiftBinary;
 import org.gradle.language.swift.SwiftComponent;
+import org.gradle.language.swift.SwiftExecutable;
 import org.gradle.language.swift.plugins.SwiftApplicationPlugin;
+import org.gradle.util.internal.TextUtil;
 
 public abstract class StandaloneSwiftApplicationPlugin implements Plugin<Project> {
     @SoftwareType(name = "swiftApplication", modelPublicType = SwiftApplication.class)
@@ -16,6 +24,7 @@ public abstract class StandaloneSwiftApplicationPlugin implements Plugin<Project
         SwiftApplication application = getApplication();
 
         project.getPlugins().apply(SwiftApplicationPlugin.class);
+        project.getPlugins().apply(CliApplicationConventionsPlugin.class);
 
         linkDslModelToPlugin(project, application);
     }
@@ -25,5 +34,18 @@ public abstract class StandaloneSwiftApplicationPlugin implements Plugin<Project
         SwiftPluginSupport.linkSwiftVersion(application, model);
 
         model.getImplementationDependencies().getDependencies().addAllLater(application.getDependencies().getImplementation().getDependencies());
+
+        project.afterEvaluate(p -> {
+            for (SwiftBinary binary : model.getBinaries().get()) {
+                if (binary instanceof SwiftExecutable) {
+                    Provider<RegularFile> executable = ((SwiftExecutable) binary).getDebuggerExecutableFile();
+                    TaskProvider<Exec> runTask = project.getTasks().register("run" + TextUtil.capitalize(binary.getName()), Exec.class, task -> {
+                        task.executable(executable.get().getAsFile().getAbsoluteFile());
+                        task.dependsOn(executable);
+                    });
+                    application.getRunTasks().add(runTask);
+                }
+            }
+        });
     }
 }

--- a/unified-prototype/unified-plugin/plugin-swift/src/main/java/org/gradle/api/experimental/swift/SwiftApplication.java
+++ b/unified-prototype/unified-plugin/plugin-swift/src/main/java/org/gradle/api/experimental/swift/SwiftApplication.java
@@ -1,8 +1,9 @@
 package org.gradle.api.experimental.swift;
 
 import org.gradle.api.experimental.common.HasApplicationDependencies;
+import org.gradle.api.experimental.common.HasCliExecutables;
 import org.gradle.declarative.dsl.model.annotations.Restricted;
 
 @Restricted
-public interface SwiftApplication extends HasSwiftTarget, HasApplicationDependencies {
+public interface SwiftApplication extends HasSwiftTarget, HasApplicationDependencies, HasCliExecutables {
 }


### PR DESCRIPTION
For software types that are implemented using Java or that target the JVM, define repositories so that the software can be built out-of-the-box without further configuration.

- Apply the foojay plugin.
- Add Maven central as a library repository.
- Also add the Google repo as a library repository when building Android software.

For software types that produce one or more CLI applications, add a `runAll` task (placeholder name) which will build and run the application for all target platforms and build types that can be built on the host machine.