### PR TITLE
fix: add requirements.txt, fix links

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+mkdocs
+mkdocs-material
+mkdocs-autorefs
+mkdocs-pdf
+mkdocs-same-dir
+mkdocs-include-markdown-plugin
+pillow
+cairosvg

--- a/unified-prototype/android-util/README.md
+++ b/unified-prototype/android-util/README.md
@@ -1,0 +1,5 @@
+---
+title: 'Unified Prototype: android-util'
+---
+
+Click "View the source of this page" to check out this example on GitHub.

--- a/unified-prototype/gradle/README.md
+++ b/unified-prototype/gradle/README.md
@@ -1,0 +1,5 @@
+---
+title: 'Unified Prototype: gradle'
+---
+
+Click "View the source of this page" to check out this example on GitHub.

--- a/unified-prototype/java-util/README.md
+++ b/unified-prototype/java-util/README.md
@@ -1,0 +1,5 @@
+---
+title: 'Unified Prototype: java-util'
+---
+
+Click "View the source of this page" to check out this example on GitHub.

--- a/unified-prototype/kotlin-js-store/README.md
+++ b/unified-prototype/kotlin-js-store/README.md
@@ -1,0 +1,5 @@
+---
+title: 'Unified Prototype: kotlin-js-store'
+---
+
+Click "View the source of this page" to check out this example on GitHub.

--- a/unified-prototype/kotlin-jvm-util/README.md
+++ b/unified-prototype/kotlin-jvm-util/README.md
@@ -1,0 +1,5 @@
+---
+title: 'Unified Prototype: kotlin-jvm-util'
+---
+
+Click "View the source of this page" to check out this example on GitHub.

--- a/unified-prototype/kotlin-util/README.md
+++ b/unified-prototype/kotlin-util/README.md
@@ -1,0 +1,5 @@
+---
+title: 'Unified Prototype: kotlin-util'
+---
+
+Click "View the source of this page" to check out this example on GitHub.

--- a/unified-prototype/swift-util/README.md
+++ b/unified-prototype/swift-util/README.md
@@ -1,0 +1,5 @@
+---
+title: 'Unified Prototype: swift-util'
+---
+
+Click "View the source of this page" to check out this example on GitHub.

--- a/unified-prototype/testbed-android-application/README.md
+++ b/unified-prototype/testbed-android-application/README.md
@@ -1,0 +1,5 @@
+---
+title: 'Unified Prototype: testbed-android-application'
+---
+
+Click "View the source of this page" to check out this example on GitHub.

--- a/unified-prototype/testbed-android-library/README.md
+++ b/unified-prototype/testbed-android-library/README.md
@@ -1,0 +1,5 @@
+---
+title: 'Unified Prototype: testbed-android-library'
+---
+
+Click "View the source of this page" to check out this example on GitHub.

--- a/unified-prototype/testbed-java-application/README.md
+++ b/unified-prototype/testbed-java-application/README.md
@@ -1,0 +1,5 @@
+---
+title: 'Unified Prototype: testbed-java-application'
+---
+
+Click "View the source of this page" to check out this example on GitHub.

--- a/unified-prototype/testbed-java-library/README.md
+++ b/unified-prototype/testbed-java-library/README.md
@@ -1,0 +1,5 @@
+---
+title: 'Unified Prototype: testbed-java-library'
+---
+
+Click "View the source of this page" to check out this example on GitHub.

--- a/unified-prototype/testbed-jvm-application/README.md
+++ b/unified-prototype/testbed-jvm-application/README.md
@@ -1,0 +1,5 @@
+---
+title: 'Unified Prototype: testbed-jvm-application'
+---
+
+Click "View the source of this page" to check out this example on GitHub.

--- a/unified-prototype/testbed-jvm-library/README.md
+++ b/unified-prototype/testbed-jvm-library/README.md
@@ -1,0 +1,5 @@
+---
+title: 'Unified Prototype: testbed-jvm-library'
+---
+
+Click "View the source of this page" to check out this example on GitHub.

--- a/unified-prototype/testbed-kotlin-application/README.md
+++ b/unified-prototype/testbed-kotlin-application/README.md
@@ -1,0 +1,5 @@
+---
+title: 'Unified Prototype: testbed-kotlin-application'
+---
+
+Click "View the source of this page" to check out this example on GitHub.

--- a/unified-prototype/testbed-kotlin-jvm-application/README.md
+++ b/unified-prototype/testbed-kotlin-jvm-application/README.md
@@ -1,0 +1,5 @@
+---
+title: 'Unified Prototype: testbed-kotlin-jvm-application'
+---
+
+Click "View the source of this page" to check out this example on GitHub.

--- a/unified-prototype/testbed-kotlin-jvm-library/README.md
+++ b/unified-prototype/testbed-kotlin-jvm-library/README.md
@@ -1,0 +1,5 @@
+---
+title: 'Unified Prototype: testbed-kotlin-jvm-library'
+---
+
+Click "View the source of this page" to check out this example on GitHub.

--- a/unified-prototype/testbed-kotlin-library/README.md
+++ b/unified-prototype/testbed-kotlin-library/README.md
@@ -1,0 +1,5 @@
+---
+title: 'Unified Prototype: testbed-kotlin-library'
+---
+
+Click "View the source of this page" to check out this example on GitHub.

--- a/unified-prototype/testbed-swift-application/README.md
+++ b/unified-prototype/testbed-swift-application/README.md
@@ -1,0 +1,5 @@
+---
+title: 'Unified Prototype: testbed-swift-application'
+---
+
+Click "View the source of this page" to check out this example on GitHub.

--- a/unified-prototype/testbed-swift-library/README.md
+++ b/unified-prototype/testbed-swift-library/README.md
@@ -1,0 +1,5 @@
+---
+title: 'Unified Prototype: testbed-swift-library'
+---
+
+Click "View the source of this page" to check out this example on GitHub.

--- a/unified-prototype/unified-plugin/README.md
+++ b/unified-prototype/unified-plugin/README.md
@@ -1,0 +1,5 @@
+---
+title: 'Unified Prototype: unified-plugin'
+---
+
+Click "View the source of this page" to check out this example on GitHub.


### PR DESCRIPTION
This PR adds a `requirements.txt` file to facilitate developing the `mkdocs` site﻿.

It also adds placeholder pages for the pages with examples, so that the user does not see broken links. This will hopefully help redirect users back to GitHub to check out the full examples using the mkdocs built-in link. Otherwise it's not so obvious how to get to the example.
