### PR TITLE
Apply new pattern to convention extensions

### DIFF
--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/AbstractAndroidSoftwarePlugin.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/AbstractAndroidSoftwarePlugin.java
@@ -24,6 +24,7 @@ public abstract class AbstractAndroidSoftwarePlugin implements Plugin<Project> {
 
     protected abstract AndroidSoftware getAndroidSoftware();
 
+    @Override
     public void apply(Project project) {
         AndroidSoftware dslModel = getAndroidSoftware();
 
@@ -111,6 +112,8 @@ public abstract class AbstractAndroidSoftwarePlugin implements Plugin<Project> {
 
     protected void configureHilt(Project project, AndroidSoftware dslModel, CommonExtension<?, ?, ?, ?, ?, ?> android) {
         if (dslModel.getHilt().getEnabled().get()) {
+            project.getLogger().info("Hilt is enabled in: " + project.getPath());
+
             // Add support for KSP
             project.getPlugins().apply("com.google.devtools.ksp");
             project.getDependencies().add("ksp", "com.google.dagger:hilt-android-compiler:2.50");
@@ -124,6 +127,8 @@ public abstract class AbstractAndroidSoftwarePlugin implements Plugin<Project> {
     @SuppressWarnings("UnstableApiUsage")
     protected void configureRoom(Project project, AndroidSoftware dslModel, CommonExtension<?, ?, ?, ?, ?, ?> android) {
         if (dslModel.getRoom().getEnabled().get()) {
+            project.getLogger().info("Room is enabled in: " + project.getPath());
+
             project.getPlugins().apply("androidx.room");
             project.getPlugins().apply("com.google.devtools.ksp");
 
@@ -145,6 +150,8 @@ public abstract class AbstractAndroidSoftwarePlugin implements Plugin<Project> {
 
     protected void configureDesugaring(Project project, AndroidSoftware dslModel, CommonExtension<?, ?, ?, ?, ?, ?> android) {
         if (dslModel.getCoreLibraryDesugaring().getEnabled().get()) {
+            project.getLogger().info("Core library desugaring is enabled in: " + project.getPath());
+
             android.compileOptions(compileOptions -> {
                 compileOptions.setCoreLibraryDesugaringEnabled(dslModel.getCoreLibraryDesugaring().getEnabled().get());
                 return null;
@@ -174,6 +181,8 @@ public abstract class AbstractAndroidSoftwarePlugin implements Plugin<Project> {
     @SuppressWarnings("UnstableApiUsage")
     protected void configureKotlinSerialization(Project project, AndroidSoftware dslModel) {
         if (dslModel.getKotlinSerialization().getEnabled().get()) {
+            project.getLogger().info("Kotlin Serialization is enabled in: " + project.getPath());
+
             project.getPlugins().apply("org.jetbrains.kotlin.plugin.serialization");
             project.getConfigurations().getByName("testImplementation").fromDependencyCollector(dslModel.getKotlinSerialization().getDependencies().getImplementation());
 

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/AndroidSoftware.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/AndroidSoftware.java
@@ -54,8 +54,8 @@ public interface AndroidSoftware {
     @Configuring
     default void kotlinSerialization(Action<? super KotlinSerialization> action) {
         KotlinSerialization kotlinSerialization = getKotlinSerialization();
-        action.execute(kotlinSerialization);
         kotlinSerialization.getEnabled().set(true);
+        action.execute(kotlinSerialization);
     }
 
     @Nested
@@ -64,8 +64,8 @@ public interface AndroidSoftware {
     @Configuring
     default void compose(Action<? super Compose> action) {
         Compose compose = getCompose();
-        action.execute(compose);
         compose.getEnabled().set(true);
+        action.execute(compose);
     }
 
     @Nested
@@ -74,8 +74,8 @@ public interface AndroidSoftware {
     @Configuring
     default void coreLibraryDesugaring(Action<? super CoreLibraryDesugaring> action) {
         CoreLibraryDesugaring coreLibraryDesugaring = getCoreLibraryDesugaring();
-        action.execute(coreLibraryDesugaring);
         coreLibraryDesugaring.getEnabled().set(true);
+        action.execute(coreLibraryDesugaring);
     }
 
     @Nested
@@ -84,8 +84,8 @@ public interface AndroidSoftware {
     @Configuring
     default void hilt(Action<? super Hilt> action) {
         Hilt hilt = getHilt();
-        action.execute(hilt);
         hilt.getEnabled().set(true);
+        action.execute(hilt);
     }
 
     @Nested
@@ -94,8 +94,8 @@ public interface AndroidSoftware {
     @Configuring
     default void room(Action<? super Room> action) {
         Room room = getRoom();
-        action.execute(room);
         room.getEnabled().set(true);
+        action.execute(room);
     }
 
     @Nested
@@ -116,7 +116,7 @@ public interface AndroidSoftware {
     @Configuring
     default void feature(Action<? super Feature> action) {
         Feature feature = getFeature();
-        action.execute(feature);
         feature.getEnabled().set(true);
+        action.execute(feature);
     }
 }

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/application/AndroidApplication.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/application/AndroidApplication.java
@@ -53,6 +53,7 @@ public interface AndroidApplication extends AndroidSoftware {
         action.execute(getDependencies());
     }
 
+    @Override
     @Nested
     AndroidApplicationBuildTypes getBuildTypes();
 

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/application/StandaloneAndroidApplicationPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/application/StandaloneAndroidApplicationPlugin.java
@@ -10,8 +10,6 @@ import org.gradle.api.experimental.android.AndroidSoftware;
 import org.gradle.api.experimental.android.nia.NiaSupport;
 import org.gradle.api.internal.plugins.software.SoftwareType;
 
-import java.util.Objects;
-
 /**
  * Creates a declarative {@link AndroidApplication} DSL model, applies the official Android plugin,
  * and links the declarative model to the official plugin.

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/extensions/Compose.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/extensions/Compose.java
@@ -5,9 +5,7 @@ import org.gradle.declarative.dsl.model.annotations.Restricted;
 
 @Restricted
 public interface Compose {
-    /**
-     * Internal property purposely not exposed to the DSL.
-     */
+    @Restricted
     Property<Boolean> getEnabled();
 
     // TODO: This should be a file property, and not assume it's a path from the root project

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/extensions/CoreLibraryDesugaring.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/extensions/CoreLibraryDesugaring.java
@@ -5,9 +5,6 @@ import org.gradle.declarative.dsl.model.annotations.Restricted;
 
 @Restricted
 public interface CoreLibraryDesugaring {
-    /**
-     * Can be enabled manually, or automatically when the TargetJavaVersion is set to 8 or higher.
-     */
     @Restricted
     Property<Boolean> getEnabled();
 

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/extensions/Hilt.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/extensions/Hilt.java
@@ -5,8 +5,6 @@ import org.gradle.declarative.dsl.model.annotations.Restricted;
 
 @Restricted
 public interface Hilt {
-    /**
-     * Internal property purposely not exposed to the DSL.
-     */
+    @Restricted
     Property<Boolean> getEnabled();
 }

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/extensions/KotlinSerialization.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/extensions/KotlinSerialization.java
@@ -14,9 +14,7 @@ import org.gradle.declarative.dsl.model.annotations.Restricted;
 @SuppressWarnings("UnstableApiUsage")
 @Restricted
 public interface KotlinSerialization {
-    /**
-     * Internal property purposely not exposed to the DSL.
-     */
+    @Restricted
     Property<Boolean> getEnabled();
 
     /**

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/extensions/Room.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/extensions/Room.java
@@ -5,6 +5,7 @@ import org.gradle.declarative.dsl.model.annotations.Restricted;
 
 @Restricted
 public interface Room {
+    @Restricted
     Property<Boolean> getEnabled();
 
     @Restricted

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/extensions/testing/Jacoco.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/extensions/testing/Jacoco.java
@@ -1,4 +1,4 @@
-package org.gradle.api.experimental.android.extensions;
+package org.gradle.api.experimental.android.extensions.testing;
 
 import org.gradle.api.provider.Property;
 import org.gradle.declarative.dsl.model.annotations.Restricted;

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/extensions/testing/Testing.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/extensions/testing/Testing.java
@@ -1,7 +1,6 @@
 package org.gradle.api.experimental.android.extensions.testing;
 
 import org.gradle.api.Action;
-import org.gradle.api.experimental.android.extensions.Jacoco;
 import org.gradle.api.tasks.Nested;
 import org.gradle.declarative.dsl.model.annotations.Configuring;
 import org.gradle.declarative.dsl.model.annotations.Restricted;

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/library/AndroidLibrary.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/library/AndroidLibrary.java
@@ -33,6 +33,7 @@ public interface AndroidLibrary extends AndroidSoftware {
         action.execute(getDependencies());
     }
 
+    @Override
     @Nested
     AndroidLibraryBuildTypes getBuildTypes();
 


### PR DESCRIPTION
- This will allow for setting an extension's properties and using enabled=false to NOT automatically apply the extension to every project of a particular software type.
- By default, with no explicit flag set, behavior remains the same.