### PR TITLE
Add support for NiA :app project to use declarative syntax

### DIFF
--- a/unified-prototype/unified-plugin/gradle/libs.versions.toml
+++ b/unified-prototype/unified-plugin/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ android = "8.3.0"
 androidTools = "31.3.0"
 hilt = "2.50"
 room = "2.6.1"
+roborazzi = "1.7.0"
 
 #Other Libs
 apache-commons = "3.3.1"
@@ -38,3 +39,4 @@ apache-commons-lang = { module = "org.apache.commons:commons-lang3", version.ref
 dependency-guard-plugin = { module = "com.dropbox.dependency-guard:com.dropbox.dependency-guard.gradle.plugin", version.ref = "dependency-guard"}
 truth = { module = "com.google.truth:truth", version.ref = "truth" }
 protobuf-plugin = { module = "com.google.protobuf:protobuf-gradle-plugin", version.ref = "protobuf" }
+roborazzi-plugin = { module = "io.github.takahirom.roborazzi:roborazzi-gradle-plugin", version.ref = "roborazzi" }

--- a/unified-prototype/unified-plugin/gradle/libs.versions.toml
+++ b/unified-prototype/unified-plugin/gradle/libs.versions.toml
@@ -13,13 +13,14 @@ firebasePerf = "1.4.2"
 gms = "4.4.1"
 hilt = "2.50"
 room = "2.6.1"
-roborazzi = "1.7.0"
 
 #Other Libs
 apache-commons = "3.3.1"
 dependency-guard = "0.4.3"
 truth = "1.4.2"
 protobuf = "0.9.4"
+oss-licenses = "0.10.6"
+roborazzi = "1.7.0"
 
 [libraries]
 # Kotlin Libs
@@ -43,6 +44,7 @@ room-plugin = { module = "androidx.room:room-gradle-plugin", version.ref = "room
 #Other Libs
 apache-commons-lang = { module = "org.apache.commons:commons-lang3", version.ref = "apache-commons" }
 dependency-guard-plugin = { module = "com.dropbox.dependency-guard:com.dropbox.dependency-guard.gradle.plugin", version.ref = "dependency-guard"}
-truth = { module = "com.google.truth:truth", version.ref = "truth" }
+oss-licenses-plugin = { group = "com.google.android.gms", name = "oss-licenses-plugin", version.ref = "oss-licenses" }
 protobuf-plugin = { module = "com.google.protobuf:protobuf-gradle-plugin", version.ref = "protobuf" }
 roborazzi-plugin = { module = "io.github.takahirom.roborazzi:roborazzi-gradle-plugin", version.ref = "roborazzi" }
+truth = { module = "com.google.truth:truth", version.ref = "truth" }

--- a/unified-prototype/unified-plugin/gradle/libs.versions.toml
+++ b/unified-prototype/unified-plugin/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ ksp = "1.9.23-1.0.20"
 # Find latest version at: https://developer.android.com/reference/tools/gradle-api
 android = "8.3.0"
 androidTools = "31.3.0"
+baselineProfile = "1.2.2"
 firebaseCrashlytics = "2.9.9"
 firebasePerf = "1.4.2"
 gms = "4.4.1"
@@ -33,6 +34,7 @@ kotlin-serialization-plugin = { module = "org.jetbrains.kotlin:kotlin-serializat
 android-agp-application = { module = "com.android.application:com.android.application.gradle.plugin", version.ref = "android" }
 android-kotlin-android = { module = "org.jetbrains.kotlin.android:org.jetbrains.kotlin.android.gradle.plugin", version.ref = "kotlin" }
 android-tools-common = { module = "com.android.tools:common", version.ref = "androidTools" }
+baseline-profile-plugin = { module = "androidx.baselineprofile:androidx.baselineprofile.gradle.plugin", version.ref = "baselineProfile"}
 firebase-perf-plugin = { module = "com.google.firebase:perf-plugin", version.ref = "firebasePerf" }
 firebase-crashlytics-plugin = { module = "com.google.firebase:firebase-crashlytics-gradle", version.ref = "firebaseCrashlytics" }
 google-services-plugin = { module = "com.google.gms.google-services:com.google.gms.google-services.gradle.plugin", version.ref = "gms" }

--- a/unified-prototype/unified-plugin/gradle/libs.versions.toml
+++ b/unified-prototype/unified-plugin/gradle/libs.versions.toml
@@ -8,6 +8,9 @@ ksp = "1.9.23-1.0.20"
 # Find latest version at: https://developer.android.com/reference/tools/gradle-api
 android = "8.3.0"
 androidTools = "31.3.0"
+firebaseCrashlytics = "2.9.9"
+firebasePerf = "1.4.2"
+gms = "4.4.1"
 hilt = "2.50"
 room = "2.6.1"
 roborazzi = "1.7.0"
@@ -29,6 +32,9 @@ kotlin-serialization-plugin = { module = "org.jetbrains.kotlin:kotlin-serializat
 android-agp-application = { module = "com.android.application:com.android.application.gradle.plugin", version.ref = "android" }
 android-kotlin-android = { module = "org.jetbrains.kotlin.android:org.jetbrains.kotlin.android.gradle.plugin", version.ref = "kotlin" }
 android-tools-common = { module = "com.android.tools:common", version.ref = "androidTools" }
+firebase-perf-plugin = { module = "com.google.firebase:perf-plugin", version.ref = "firebasePerf" }
+firebase-crashlytics-plugin = { module = "com.google.firebase:firebase-crashlytics-gradle", version.ref = "firebaseCrashlytics" }
+google-services-plugin = { module = "com.google.gms.google-services:com.google.gms.google-services.gradle.plugin", version.ref = "gms" }
 hilt-android-plugin = { module = "com.google.dagger:hilt-android-gradle-plugin", version.ref = "hilt" }
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt"}
 hilt-compiler = { module = "com.google.dagger:hilt-android-compiler", version.ref = "hilt" }

--- a/unified-prototype/unified-plugin/plugin-android/build.gradle.kts
+++ b/unified-prototype/unified-plugin/plugin-android/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
     api(libs.android.kotlin.android)
 
     implementation(project(":plugin-jvm"))
+    implementation(libs.baseline.profile.plugin)
     implementation(libs.dependency.guard.plugin)
     implementation(libs.ksp.plugin)
     implementation(libs.hilt.android.plugin)

--- a/unified-prototype/unified-plugin/plugin-android/build.gradle.kts
+++ b/unified-prototype/unified-plugin/plugin-android/build.gradle.kts
@@ -21,6 +21,9 @@ dependencies {
     implementation(libs.room.plugin)
     implementation(libs.protobuf.plugin)
     implementation(libs.roborazzi.plugin)
+    implementation(libs.google.services.plugin)
+    implementation(libs.firebase.perf.plugin)
+    implementation(libs.firebase.crashlytics.plugin)
 
     implementation(libs.apache.commons.lang)
     implementation(libs.android.tools.common)

--- a/unified-prototype/unified-plugin/plugin-android/build.gradle.kts
+++ b/unified-prototype/unified-plugin/plugin-android/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     implementation(libs.google.services.plugin)
     implementation(libs.firebase.perf.plugin)
     implementation(libs.firebase.crashlytics.plugin)
+    implementation(libs.oss.licenses.plugin)
 
     implementation(libs.apache.commons.lang)
     implementation(libs.android.tools.common)

--- a/unified-prototype/unified-plugin/plugin-android/build.gradle.kts
+++ b/unified-prototype/unified-plugin/plugin-android/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     implementation(libs.kotlin.serialization.plugin)
     implementation(libs.room.plugin)
     implementation(libs.protobuf.plugin)
+    implementation(libs.roborazzi.plugin)
 
     implementation(libs.apache.commons.lang)
     implementation(libs.android.tools.common)

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/AbstractAndroidSoftwarePlugin.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/AbstractAndroidSoftwarePlugin.java
@@ -5,7 +5,6 @@ import com.android.build.api.dsl.BuildType;
 import com.android.build.api.dsl.CommonExtension;
 import com.android.build.api.dsl.UnitTestOptions;
 import com.google.devtools.ksp.gradle.KspExtension;
-import org.gradle.api.Action;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.Plugin;
@@ -14,11 +13,11 @@ import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.experimental.android.extensions.testing.AndroidTestDependencies;
 import org.gradle.api.experimental.android.extensions.testing.TestOptions;
 import org.gradle.api.experimental.android.extensions.testing.Testing;
-import org.gradle.api.provider.Property;
 import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension;
 
 import java.io.File;
 
+import static org.gradle.api.experimental.android.AndroidSupport.ifPresent;
 import static org.gradle.api.experimental.android.extensions.ComposeSupport.configureCompose;
 
 public abstract class AbstractAndroidSoftwarePlugin implements Plugin<Project> {
@@ -52,6 +51,7 @@ public abstract class AbstractAndroidSoftwarePlugin implements Plugin<Project> {
         dslModel.getHilt().getEnabled().convention(false);
         dslModel.getRoom().getEnabled().convention(false);
         dslModel.getRoom().getVersion().convention("2.6.1");
+        dslModel.getLicenses().getEnabled().convention(false);
 
         // Setup Test Options conventions
         dslModel.getTesting().getTestOptions().getIncludeAndroidResources().convention(false);
@@ -108,12 +108,12 @@ public abstract class AbstractAndroidSoftwarePlugin implements Plugin<Project> {
 
         configureKotlinSerialization(project, dslModel);
         configureDesugaring(project, dslModel, android);
-        configureHilt(project, dslModel, android);
+        configureHilt(project, dslModel);
         configureCompose(project, dslModel, android);
-        configureRoom(project, dslModel, android);
+        configureRoom(project, dslModel);
     }
 
-    protected void configureHilt(Project project, AndroidSoftware dslModel, CommonExtension<?, ?, ?, ?, ?, ?> android) {
+    protected void configureHilt(Project project, AndroidSoftware dslModel) {
         if (dslModel.getHilt().getEnabled().get()) {
             project.getLogger().info("Hilt is enabled in: " + project.getPath());
 
@@ -130,7 +130,7 @@ public abstract class AbstractAndroidSoftwarePlugin implements Plugin<Project> {
     }
 
     @SuppressWarnings("UnstableApiUsage")
-    protected void configureRoom(Project project, AndroidSoftware dslModel, CommonExtension<?, ?, ?, ?, ?, ?> android) {
+    protected void configureRoom(Project project, AndroidSoftware dslModel) {
         if (dslModel.getRoom().getEnabled().get()) {
             project.getLogger().info("Room is enabled in: " + project.getPath());
 
@@ -227,11 +227,5 @@ public abstract class AbstractAndroidSoftwarePlugin implements Plugin<Project> {
         configurations.getByName(name + "Implementation").fromDependencyCollector(dependencies.getImplementation());
         configurations.getByName(name + "CompileOnly").fromDependencyCollector(dependencies.getCompileOnly());
         configurations.getByName(name + "RuntimeOnly").fromDependencyCollector(dependencies.getRuntimeOnly());
-    }
-
-    protected <T> void ifPresent(Property<T> property, Action<T> action) {
-        if (property.isPresent()) {
-            action.execute(property.get());
-        }
     }
 }

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/AbstractAndroidSoftwarePlugin.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/AbstractAndroidSoftwarePlugin.java
@@ -4,8 +4,6 @@ import androidx.room.gradle.RoomExtension;
 import com.android.build.api.dsl.BuildType;
 import com.android.build.api.dsl.CommonExtension;
 import com.android.build.api.dsl.UnitTestOptions;
-import com.android.build.gradle.BaseExtension;
-import com.android.build.gradle.ProguardFiles;
 import com.google.devtools.ksp.gradle.KspExtension;
 import org.gradle.api.Action;
 import org.gradle.api.JavaVersion;
@@ -20,7 +18,6 @@ import org.gradle.api.provider.Property;
 import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension;
 
 import java.io.File;
-import java.util.Objects;
 
 import static org.gradle.api.experimental.android.extensions.ComposeSupport.configureCompose;
 
@@ -61,6 +58,7 @@ public abstract class AbstractAndroidSoftwarePlugin implements Plugin<Project> {
         dslModel.getTesting().getTestOptions().getReturnDefaultValues().convention(false);
         dslModel.getTesting().getJacoco().getEnabled().convention(false);
         dslModel.getTesting().getJacoco().getVersion().convention("0.8.7");
+        dslModel.getTesting().getRoborazzi().getEnabled().convention(false);
     }
 
     /**
@@ -126,6 +124,8 @@ public abstract class AbstractAndroidSoftwarePlugin implements Plugin<Project> {
             // Add support for Hilt
             project.getPlugins().apply("dagger.hilt.android.plugin");
             project.getDependencies().add("implementation", "com.google.dagger:hilt-android:2.50");
+
+            project.getDependencies().add("kspTest", "com.google.dagger:hilt-android-compiler:2.50");
         }
     }
 
@@ -181,6 +181,14 @@ public abstract class AbstractAndroidSoftwarePlugin implements Plugin<Project> {
         ConfigurationContainer configurations = project.getConfigurations();
         configurations.getByName("testImplementation").fromDependencyCollector(testDependencies.getImplementation());
         configurations.getByName("androidTestImplementation").fromDependencyCollector(testDependencies.getAndroidImplementation());
+
+        configureRoborazzi(project, dslModel);
+    }
+
+    protected void configureRoborazzi(Project project, AndroidSoftware dslModel) {
+        if (dslModel.getTesting().getRoborazzi().getEnabled().get()) {
+            project.getPlugins().apply("io.github.takahirom.roborazzi");
+        }
     }
 
     @SuppressWarnings("UnstableApiUsage")

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/AndroidSoftware.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/AndroidSoftware.java
@@ -10,6 +10,7 @@ import org.gradle.api.experimental.android.extensions.KotlinSerialization;
 import org.gradle.api.experimental.android.extensions.Room;
 import org.gradle.api.experimental.android.extensions.testing.Testing;
 import org.gradle.api.experimental.android.nia.Feature;
+import org.gradle.api.experimental.android.nia.Licenses;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Nested;
 import org.gradle.declarative.dsl.model.annotations.Configuring;
@@ -118,5 +119,19 @@ public interface AndroidSoftware {
         Feature feature = getFeature();
         feature.getEnabled().set(true);
         action.execute(feature);
+    }
+
+    /**
+     * Support for NiA projects using the com.google.android.gms.oss-licenses-plugin
+     * TODO: This is a temporary solution until we have a better way of applying plugins
+     */
+    @Nested
+    Licenses getLicenses();
+
+    @Configuring
+    default void licenses(Action<? super Licenses> action) {
+        Licenses licenses = getLicenses();
+        licenses.getEnabled().set(true);
+        action.execute(licenses);
     }
 }

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/AndroidSoftware.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/AndroidSoftware.java
@@ -3,6 +3,7 @@ package org.gradle.api.experimental.android;
 import com.android.build.api.dsl.BaseFlavor;
 import com.android.build.api.dsl.CommonExtension;
 import org.gradle.api.Action;
+import org.gradle.api.experimental.android.extensions.BaselineProfile;
 import org.gradle.api.experimental.android.extensions.Compose;
 import org.gradle.api.experimental.android.extensions.CoreLibraryDesugaring;
 import org.gradle.api.experimental.android.extensions.Hilt;
@@ -10,7 +11,7 @@ import org.gradle.api.experimental.android.extensions.KotlinSerialization;
 import org.gradle.api.experimental.android.extensions.Room;
 import org.gradle.api.experimental.android.extensions.testing.Testing;
 import org.gradle.api.experimental.android.nia.Feature;
-import org.gradle.api.experimental.android.nia.Licenses;
+import org.gradle.api.experimental.android.extensions.Licenses;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Nested;
 import org.gradle.declarative.dsl.model.annotations.Configuring;
@@ -40,6 +41,9 @@ public interface AndroidSoftware {
      */
     @Restricted
     Property<Integer> getJdkVersion();
+
+    @Restricted
+    Property<Boolean> getVectorDrawablesUseSupportLibrary();
 
     AndroidSoftwareBuildTypes getBuildTypes();
 
@@ -109,7 +113,7 @@ public interface AndroidSoftware {
 
     /**
      * Support for NiA convention projects defining features.
-     * TODO: This is a temporary solution until we have a proper feature model.
+     * TODO:DG This is a temporary solution until we have a proper feature model.
      */
     @Nested
     Feature getFeature();
@@ -123,7 +127,7 @@ public interface AndroidSoftware {
 
     /**
      * Support for NiA projects using the com.google.android.gms.oss-licenses-plugin
-     * TODO: This is a temporary solution until we have a better way of applying plugins
+     * TODO:DG This is a temporary solution until we have a better way of applying plugins
      */
     @Nested
     Licenses getLicenses();
@@ -133,5 +137,15 @@ public interface AndroidSoftware {
         Licenses licenses = getLicenses();
         licenses.getEnabled().set(true);
         action.execute(licenses);
+    }
+
+    @Nested
+    BaselineProfile getBaselineProfile();
+
+    @Configuring
+    default void baselineProfile(Action<? super BaselineProfile> action) {
+        BaselineProfile baselineProfile = getBaselineProfile();
+        baselineProfile.getEnabled().set(true);
+        action.execute(baselineProfile);
     }
 }

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/AndroidSoftwareBuildType.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/AndroidSoftwareBuildType.java
@@ -1,6 +1,7 @@
 package org.gradle.api.experimental.android;
 
 import org.gradle.api.Action;
+import org.gradle.api.experimental.android.extensions.BaselineProfile;
 import org.gradle.api.experimental.android.extensions.Minify;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ListProperty;
@@ -49,4 +50,14 @@ public interface AndroidSoftwareBuildType {
 
     @Inject
     ObjectFactory getObjectFactory();
+
+    @Nested
+    BaselineProfile getBaselineProfile();
+
+    @Configuring
+    default void baselineProfile(Action<? super BaselineProfile> action) {
+        BaselineProfile baselineProfile = getBaselineProfile();
+        baselineProfile.getEnabled().set(true);
+        action.execute(baselineProfile);
+    }
 }

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/AndroidSoftwareBuildType.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/AndroidSoftwareBuildType.java
@@ -2,9 +2,14 @@ package org.gradle.api.experimental.android;
 
 import org.gradle.api.Action;
 import org.gradle.api.experimental.android.extensions.Minify;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ListProperty;
 import org.gradle.api.tasks.Nested;
+import org.gradle.declarative.dsl.model.annotations.Adding;
 import org.gradle.declarative.dsl.model.annotations.Configuring;
 import org.gradle.declarative.dsl.model.annotations.Restricted;
+
+import javax.inject.Inject;
 
 @Restricted
 public interface AndroidSoftwareBuildType {
@@ -20,4 +25,28 @@ public interface AndroidSoftwareBuildType {
     default void minify(Action<? super Minify> action) {
         action.execute(getMinify());
     }
+
+    ListProperty<ProguardFile> getProguardFiles();
+    ListProperty<ProguardFile> getDefaultProguardFiles();
+
+    @Adding
+    default ProguardFile proguardFile(Action<? super ProguardFile> configure) {
+        ProguardFile proguardFile = getObjectFactory().newInstance(ProguardFile.class);
+        proguardFile.getName().convention("<no name>");
+        configure.execute(proguardFile);
+        getProguardFiles().add(proguardFile);
+        return proguardFile;
+    }
+
+    @Adding
+    default ProguardFile defaultProguardFile(Action<? super ProguardFile> configure) {
+        ProguardFile proguardFile = getObjectFactory().newInstance(ProguardFile.class);
+        proguardFile.getName().convention("<no name>");
+        configure.execute(proguardFile);
+        getDefaultProguardFiles().add(proguardFile);
+        return proguardFile;
+    }
+
+    @Inject
+    ObjectFactory getObjectFactory();
 }

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/AndroidSupport.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/AndroidSupport.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.experimental.android;
+
+import org.gradle.api.Action;
+import org.gradle.api.provider.Property;
+
+/**
+ * Static util class containing common methods.
+ */
+public class AndroidSupport {
+    private AndroidSupport() { /* not instantiable */ }
+
+    public static <T> void ifPresent(Property<T> property, Action<T> action) {
+        if (property.isPresent()) {
+            action.execute(property.get());
+        }
+    }
+}

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/ProguardFile.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/ProguardFile.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.experimental.android;
+
+import org.gradle.api.provider.Property;
+import org.gradle.declarative.dsl.model.annotations.Restricted;
+
+@Restricted
+public interface ProguardFile {
+    @Restricted
+    Property<String> getName();
+}

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/application/AndroidApplication.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/application/AndroidApplication.java
@@ -20,6 +20,7 @@ import com.android.build.api.dsl.ApplicationBaseFlavor;
 import org.gradle.api.Action;
 import org.gradle.api.experimental.android.AndroidSoftware;
 import org.gradle.api.experimental.android.extensions.DependencyGuard;
+import org.gradle.api.experimental.android.extensions.Firebase;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Nested;
 import org.gradle.declarative.dsl.model.annotations.Configuring;
@@ -71,5 +72,15 @@ public interface AndroidApplication extends AndroidSoftware {
         DependencyGuard dependencyGuard = getDependencyGuard();
         dependencyGuard.getEnabled().set(true);
         action.execute(dependencyGuard);
+    }
+
+    @Nested
+    Firebase getFirebase();
+
+    @Configuring
+    default void firebase(Action<? super Firebase> action) {
+        Firebase firebase = getFirebase();
+        firebase.getEnabled().set(true);
+        action.execute(firebase);
     }
 }

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/application/AndroidApplication.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/application/AndroidApplication.java
@@ -21,6 +21,8 @@ import org.gradle.api.Action;
 import org.gradle.api.experimental.android.AndroidSoftware;
 import org.gradle.api.experimental.android.extensions.DependencyGuard;
 import org.gradle.api.experimental.android.extensions.Firebase;
+import org.gradle.api.experimental.android.nia.DimensionStrategy;
+import org.gradle.api.experimental.android.nia.Flavors;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Nested;
 import org.gradle.declarative.dsl.model.annotations.Configuring;
@@ -82,5 +84,23 @@ public interface AndroidApplication extends AndroidSoftware {
         Firebase firebase = getFirebase();
         firebase.getEnabled().set(true);
         action.execute(firebase);
+    }
+
+    @Nested
+    Flavors getFlavors();
+
+    @Configuring
+    default void flavors(Action<? super Flavors> action) {
+        Flavors flavors = getFlavors();
+        flavors.getEnabled().set(true);
+        action.execute(flavors);
+    }
+
+    @Nested
+    DimensionStrategy getMissingDimensionStrategy();
+
+    @Configuring
+    default void missingDimensionStrategy(Action<? super DimensionStrategy> action) {
+        action.execute(getMissingDimensionStrategy());
     }
 }

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/application/StandaloneAndroidApplicationPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/application/StandaloneAndroidApplicationPlugin.java
@@ -41,6 +41,8 @@ public abstract class StandaloneAndroidApplicationPlugin extends AbstractAndroid
         dslModel.getBuildTypes().getDebug().getApplicationIdSuffix().convention((String) null);
         dslModel.getBuildTypes().getRelease().getApplicationIdSuffix().convention((String) null);
 
+        dslModel.getFlavors().getEnabled().convention(false);
+
         // Register an afterEvaluate listener before we apply the Android plugin to ensure we can
         // run actions before Android does.
         project.afterEvaluate(p -> linkDslModelToPlugin(p, dslModel));

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/application/StandaloneAndroidApplicationPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/application/StandaloneAndroidApplicationPlugin.java
@@ -10,6 +10,8 @@ import org.gradle.api.experimental.android.AndroidSoftware;
 import org.gradle.api.experimental.android.nia.NiaSupport;
 import org.gradle.api.internal.plugins.software.SoftwareType;
 
+import static org.gradle.api.experimental.android.AndroidSupport.ifPresent;
+
 /**
  * Creates a declarative {@link AndroidApplication} DSL model, applies the official Android plugin,
  * and links the declarative model to the official plugin.
@@ -35,6 +37,9 @@ public abstract class StandaloneAndroidApplicationPlugin extends AbstractAndroid
 
         dslModel.getFirebase().getEnabled().convention(false);
         dslModel.getFirebase().getVersion().convention("32.4.0");
+
+        dslModel.getBuildTypes().getDebug().getApplicationIdSuffix().convention((String) null);
+        dslModel.getBuildTypes().getRelease().getApplicationIdSuffix().convention((String) null);
 
         // Register an afterEvaluate listener before we apply the Android plugin to ensure we can
         // run actions before Android does.

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/application/StandaloneAndroidApplicationPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/application/StandaloneAndroidApplicationPlugin.java
@@ -33,6 +33,9 @@ public abstract class StandaloneAndroidApplicationPlugin extends AbstractAndroid
         // Setup application-specific conventions
         dslModel.getDependencyGuard().getEnabled().convention(false);
 
+        dslModel.getFirebase().getEnabled().convention(false);
+        dslModel.getFirebase().getVersion().convention("32.4.0");
+
         // Register an afterEvaluate listener before we apply the Android plugin to ensure we can
         // run actions before Android does.
         project.afterEvaluate(p -> linkDslModelToPlugin(p, dslModel));

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/application/StandaloneAndroidApplicationPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/application/StandaloneAndroidApplicationPlugin.java
@@ -69,7 +69,7 @@ public abstract class StandaloneAndroidApplicationPlugin extends AbstractAndroid
             return null;
         });
 
-        // TODO: All this configuration should be moved to the NiA project
+        // TODO:DG All this configuration should be moved to the NiA project
         if (NiaSupport.isNiaProject(project)) {
             NiaSupport.configureNiaApplication(project, dslModel);
         }

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/extensions/BaselineProfile.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/extensions/BaselineProfile.java
@@ -22,31 +22,20 @@ import org.gradle.api.tasks.Nested;
 import org.gradle.declarative.dsl.model.annotations.Configuring;
 import org.gradle.declarative.dsl.model.annotations.Restricted;
 
-@Restricted
-public interface Protobuf {
-    @Restricted
+public interface BaselineProfile {
+    /**
+     * Internal property purposely not exposed to the DSL.
+     */
     Property<Boolean> getEnabled();
 
+    @Restricted
+    Property<Boolean> getAutomaticGenerationDuringBuild();
+
     @Nested
-    ProtobufDependencies getDependencies();
+    BaselineProfileDependencies getDependencies();
 
     @Configuring
-    default void dependencies(Action<? super ProtobufDependencies> action) {
+    default void dependencies(Action<? super BaselineProfileDependencies> action) {
         action.execute(getDependencies());
     }
-
-    // TODO:DG This is modeled in a very limited manner for now
-    @Restricted
-    Property<String> getOption();
-
-    /**
-     * Protobuf library version to use.
-     */
-    @Restricted
-    Property<String> getVersion();
-
-    // TODO:DG Should be a File based property, when we support these
-    @Restricted
-    Property<String> getGeneratedRootDir();
 }
-

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/extensions/BaselineProfileDependencies.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/extensions/BaselineProfileDependencies.java
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
-package org.gradle.api.experimental.android.nia;
+package org.gradle.api.experimental.android.extensions;
 
-import org.gradle.api.provider.Property;
-import org.gradle.declarative.dsl.model.annotations.Restricted;
+import org.gradle.api.artifacts.dsl.Dependencies;
+import org.gradle.api.artifacts.dsl.DependencyCollector;
 
-@Restricted
-public interface Licenses {
-    /**
-     * Internal property purposely not exposed to the DSL.
-     */
-    Property<Boolean> getEnabled();
+@SuppressWarnings("UnstableApiUsage")
+public interface BaselineProfileDependencies extends Dependencies {
+    DependencyCollector getProfile();
 }

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/extensions/Compose.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/extensions/Compose.java
@@ -8,7 +8,7 @@ public interface Compose {
     @Restricted
     Property<Boolean> getEnabled();
 
-    // TODO: This should be a file property, and not assume it's a path from the root project
+    // TODO:DG This should be a file property, and not assume it's a path from the root project
     @Restricted
     Property<String> getStabilityConfigurationFilePath();
 

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/extensions/Firebase.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/extensions/Firebase.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.experimental.android.extensions;
+
+import org.gradle.api.provider.Property;
+import org.gradle.declarative.dsl.model.annotations.Restricted;
+
+@Restricted
+public interface Firebase {
+    @Restricted
+    Property<Boolean> getEnabled();
+
+    @Restricted
+    Property<String> getVersion();
+
+    @Restricted
+    Property<Boolean> getMappingFileUploadEnabled();
+}

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/extensions/Licenses.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/extensions/Licenses.java
@@ -16,37 +16,13 @@
 
 package org.gradle.api.experimental.android.extensions;
 
-import org.gradle.api.Action;
 import org.gradle.api.provider.Property;
-import org.gradle.api.tasks.Nested;
-import org.gradle.declarative.dsl.model.annotations.Configuring;
 import org.gradle.declarative.dsl.model.annotations.Restricted;
 
 @Restricted
-public interface Protobuf {
-    @Restricted
-    Property<Boolean> getEnabled();
-
-    @Nested
-    ProtobufDependencies getDependencies();
-
-    @Configuring
-    default void dependencies(Action<? super ProtobufDependencies> action) {
-        action.execute(getDependencies());
-    }
-
-    // TODO:DG This is modeled in a very limited manner for now
-    @Restricted
-    Property<String> getOption();
-
+public interface Licenses {
     /**
-     * Protobuf library version to use.
+     * Internal property purposely not exposed to the DSL.
      */
-    @Restricted
-    Property<String> getVersion();
-
-    // TODO:DG Should be a File based property, when we support these
-    @Restricted
-    Property<String> getGeneratedRootDir();
+    Property<Boolean> getEnabled();
 }
-

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/extensions/testing/Jacoco.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/extensions/testing/Jacoco.java
@@ -8,9 +8,6 @@ import org.gradle.declarative.dsl.model.annotations.Restricted;
  */
 @Restricted
 public interface Jacoco {
-    /**
-     * Internal property purposely not exposed to the DSL.
-     */
     @Restricted
     Property<Boolean> getEnabled();
 

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/extensions/testing/Roborazzi.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/extensions/testing/Roborazzi.java
@@ -1,2 +1,26 @@
-package org.gradle.api.experimental.android.extensions.testing;public interface Roborazzi {
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.experimental.android.extensions.testing;
+
+import org.gradle.api.provider.Property;
+import org.gradle.declarative.dsl.model.annotations.Restricted;
+
+@Restricted
+public interface Roborazzi {
+    @Restricted
+    Property<Boolean> getEnabled();
 }

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/extensions/testing/Roborazzi.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/extensions/testing/Roborazzi.java
@@ -1,0 +1,2 @@
+package org.gradle.api.experimental.android.extensions.testing;public interface Roborazzi {
+}

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/extensions/testing/Testing.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/extensions/testing/Testing.java
@@ -21,6 +21,16 @@ public interface Testing {
     }
 
     @Nested
+    Roborazzi getRoborazzi();
+
+    @Configuring
+    default void roborazzi(Action<? super Roborazzi> action) {
+        Roborazzi roborazzi = getRoborazzi();
+        roborazzi.getEnabled().set(true);
+        action.execute(roborazzi);
+    }
+
+    @Nested
     TestOptions getTestOptions();
 
     @Configuring

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/library/AndroidLibrary.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/library/AndroidLibrary.java
@@ -44,7 +44,7 @@ public interface AndroidLibrary extends AndroidSoftware {
         action.execute(getBuildTypes());
     }
 
-    // TODO: We really want to model a list of consumer proguard files here, but can't yet
+    // TODO:DG We really want to model a list of consumer proguard files here, but can't yet
     @Restricted
     Property<String> getConsumerProguardFile();
 

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/library/StandaloneAndroidLibraryPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/library/StandaloneAndroidLibraryPlugin.java
@@ -5,10 +5,8 @@ import com.android.build.api.dsl.LibraryExtension;
 import com.android.build.api.variant.LibraryAndroidComponentsExtension;
 import com.google.protobuf.gradle.ProtobufExtension;
 import org.gradle.api.Project;
-import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.Dependency;
-import org.gradle.api.artifacts.dsl.DependencyCollector;
 import org.gradle.api.experimental.android.AbstractAndroidSoftwarePlugin;
 import org.gradle.api.experimental.android.AndroidSoftware;
 import org.gradle.api.experimental.android.nia.NiaSupport;
@@ -116,19 +114,6 @@ public abstract class StandaloneAndroidLibraryPlugin extends AbstractAndroidSoft
         Preconditions.checkState(protocDeps.size() == 1, "Should have a single dependency, but had: " + protocDeps.size());
         Dependency protocDep = protocDeps.iterator().next();
         return protocDep.getGroup() + ":" + protocDep.getName() + ":" + protocDep.getVersion();
-    }
-
-    private File resolveSingleDependency(Project project, DependencyCollector dependencyCollector) {
-        Configuration resolver = project.getConfigurations().detachedConfiguration();
-        resolver.setCanBeResolved(true);
-        resolver.fromDependencyCollector(dependencyCollector);
-
-        Set<Dependency> deps = dependencyCollector.getDependencies().get();
-        Preconditions.checkState(deps.size() == 1, "Should have a single dependency, but had: " + deps.size());
-
-        Set<File> files = resolver.resolve();
-        Preconditions.checkState(files.size() == 1, "Should have resolved a single file, but resolved: " + files.size());
-        return files.iterator().next();
     }
 
     @SuppressWarnings("UnstableApiUsage")

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/library/StandaloneAndroidLibraryPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/library/StandaloneAndroidLibraryPlugin.java
@@ -17,6 +17,8 @@ import java.io.File;
 import java.util.Objects;
 import java.util.Set;
 
+import static org.gradle.api.experimental.android.AndroidSupport.ifPresent;
+
 /**
  * Creates a declarative {@link AndroidLibrary} DSL model, applies the official Android plugin,
  * and links the declarative model to the official plugin.

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/library/StandaloneAndroidLibraryPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/library/StandaloneAndroidLibraryPlugin.java
@@ -63,7 +63,7 @@ public abstract class StandaloneAndroidLibraryPlugin extends AbstractAndroidSoft
 
         configureProtobuf(project, dslModel, android);
 
-        // TODO: All this configuration should be moved to the NiA project
+        // TODO:DG All this configuration should be moved to the NiA project
         if (NiaSupport.isNiaProject(project)) {
             NiaSupport.configureNiaLibrary(project, dslModel);
         }
@@ -92,7 +92,7 @@ public abstract class StandaloneAndroidLibraryPlugin extends AbstractAndroidSoft
                 });
 
                 /*
-                 * TODO: We don't want to rely on beforeVariants here, but how to do without hardcoding:
+                 * TODO:DG We don't want to rely on beforeVariants here, but how to do without hardcoding:
                  *  the NiA variants: "demoDebug, demoRelease, prodDebug, prodRelease"?
                  * This would seem to require some sort of ProductFlavor support (and maybe enumerated buildTypes?)
                  * which we don't want to add just yet.

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/nia/DimensionStrategy.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/nia/DimensionStrategy.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.experimental.android.nia;
+
+import org.gradle.api.provider.Property;
+import org.gradle.declarative.dsl.model.annotations.Restricted;
+
+@Restricted
+public interface DimensionStrategy {
+    @Restricted
+    Property<String> getName();
+
+    @Restricted
+    Property<String> getValue();
+}

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/nia/Flavors.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/nia/Flavors.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.experimental.android.nia;
+
+import org.gradle.api.provider.Property;
+import org.gradle.declarative.dsl.model.annotations.Restricted;
+
+@Restricted
+public interface Flavors {
+    /**
+     * Internal property purposely not exposed to the DSL.
+     */
+    Property<Boolean> getEnabled();
+}

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/nia/Licenses.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/nia/Licenses.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.experimental.android.nia;
+
+import org.gradle.api.provider.Property;
+import org.gradle.declarative.dsl.model.annotations.Restricted;
+
+@Restricted
+public interface Licenses {
+    /**
+     * Internal property purposely not exposed to the DSL.
+     */
+    Property<Boolean> getEnabled();
+}

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/nia/NiaSupport.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/nia/NiaSupport.java
@@ -81,7 +81,7 @@ public final class NiaSupport {
         testOptions.setAnimationsDisabled(true);
 
         configureBadgingTasks(project, androidAppComponents);
-        configureDependencyGuard(project, dslModel, androidApp);
+        configureDependencyGuard(project, dslModel);
     }
 
     @SuppressWarnings("UnstableApiUsage")
@@ -341,8 +341,8 @@ public final class NiaSupport {
             JacocoPluginExtension jacocoPluginExtension = project.getExtensions().getByType(JacocoPluginExtension.class);
             jacocoPluginExtension.setToolVersion(dslModel.getTesting().getJacoco().getVersion().get());
 
-            LibraryAndroidComponentsExtension androidLibComponents = project.getExtensions().getByType(LibraryAndroidComponentsExtension.class);
-            androidLibComponents.onVariants(androidLibComponents.selector().all(), variant -> {
+            AndroidComponentsExtension<?, ?, ?> androidComponentsExtension = project.getExtensions().getByType(AndroidComponentsExtension.class);
+            androidComponentsExtension.onVariants(androidComponentsExtension.selector().all(), variant -> {
                 final String testTaskName = "test" + StringUtils.capitalize(variant.getName()) + "UnitTest";
                 final File buildDir = project.getLayout().getBuildDirectory().get().getAsFile();
                 project.getTasks().register("jacoco" + StringUtils.capitalize(testTaskName) + "Report", JacocoReport.class, task -> {
@@ -382,7 +382,7 @@ public final class NiaSupport {
         }
     }
 
-    private static void configureDependencyGuard(Project project, AndroidApplication dslModel, CommonExtension<?, ?, ?, ?, ?, ?> android) {
+    private static void configureDependencyGuard(Project project, AndroidApplication dslModel) {
         if (dslModel.getDependencyGuard().getEnabled().get()) {
             // Slight change of behavior here - NiA just applies this plugin to all applications, which seems unnecessary
             project.getPlugins().apply("com.dropbox.dependency-guard");

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/nia/NiaSupport.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/nia/NiaSupport.java
@@ -48,7 +48,7 @@ import java.util.stream.Collectors;
 
 import static org.gradle.api.experimental.android.AndroidSupport.ifPresent;
 
-// TODO: This class should be moved to the NiA project
+// TODO:DG This class should be moved to the NiA project
 /**
  * This is a utility class that configures an Android project with conventions
  * for the Now in Android project.
@@ -112,17 +112,10 @@ public final class NiaSupport {
         configureGradleManagedDevices(android);
         configureLint(android);
         configurePrintApksTask(project, androidComponents);
-        configureLicenses(project, dslModel);
 
         configureJacoco(project, dslModel, android);
 
         configureFeature(project, dslModel, android);
-    }
-
-    private static void configureLicenses(Project project, AndroidSoftware dslModel) {
-        if (dslModel.getLicenses().getEnabled().get()) {
-            project.getPlugins().apply("com.google.android.gms.oss-licenses-plugin");
-        }
     }
 
     @SuppressWarnings("UnstableApiUsage")

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/nia/PrintApkLocationTask.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/nia/PrintApkLocationTask.java
@@ -36,7 +36,7 @@ import org.gradle.work.DisableCachingByDefault;
 import java.io.File;
 import java.nio.file.Path;
 
-@DisableCachingByDefault(because = "Prints output") // TODO: Not converted
+@DisableCachingByDefault(because = "Prints output")
 public abstract class PrintApkLocationTask extends DefaultTask {
     @PathSensitive(PathSensitivity.RELATIVE)
     @InputDirectory

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/nia/package-info.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/nia/package-info.java
@@ -1,4 +1,4 @@
-// TODO: Everything in this package should be moved to the NiA project
+// TODO:DG Everything in this package should be moved to the NiA project
 /**
  * Contains build logic necessary for the Now In Android (NiA) project as
  * a temporary workaround to support that project using Declarative Gradle.


### PR DESCRIPTION
Adds support for many new plugins:

- Proguard
- BaselineProfile
- Firebase
- GMS OSS Licenses
- Roborazzi

Fixes contentType to only be used in appropriate places, fully opt in for applications.

Support for various other minor flags used by NiA.

// Using TODO:DG for known limitations

**https://github.com/gradle/declarative-gradle/pull/90 should be merged first**