### PR TITLE
Upgrade the Gradle wrapper to the latest nightly, requiring conventions to be explicitly enabled in projects

### DIFF
--- a/unified-prototype/gradle/wrapper/gradle-wrapper.properties
+++ b/unified-prototype/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-8.9-branch-gh_declarative_convention_rules-20240520154301+0000-bin.zip
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-8.10-20240614182247+0000-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/unified-prototype/unified-plugin/internal-testing-utils/src/main/groovy/org/gradle/test/fixtures/AbstractSpecification.groovy
+++ b/unified-prototype/unified-plugin/internal-testing-utils/src/main/groovy/org/gradle/test/fixtures/AbstractSpecification.groovy
@@ -8,6 +8,7 @@ import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import spock.lang.Specification
 
+import static org.gradle.testkit.runner.TaskOutcome.FAILED
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
 class AbstractSpecification extends Specification {
@@ -47,6 +48,17 @@ class AbstractSpecification extends Specification {
                 .build()
         tasks.each { task ->
             assert result.task(task).outcome == SUCCESS
+        }
+    }
+
+    def fails(String... tasks) {
+        result = GradleRunner.create()
+                .withProjectDir(getTestDirectory())
+                .withArguments(tasks)
+                .withPluginClasspath()
+                .run()
+        tasks.each { task ->
+            assert result.task(task).outcome == FAILED
         }
     }
 }

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/AndroidSoftware.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/AndroidSoftware.java
@@ -60,9 +60,7 @@ public interface AndroidSoftware extends HasLinting {
 
     @Configuring
     default void kotlinSerialization(Action<? super KotlinSerialization> action) {
-        KotlinSerialization kotlinSerialization = getKotlinSerialization();
-        kotlinSerialization.getEnabled().set(true);
-        action.execute(kotlinSerialization);
+        action.execute(getKotlinSerialization());
     }
 
     @Nested
@@ -70,9 +68,7 @@ public interface AndroidSoftware extends HasLinting {
 
     @Configuring
     default void compose(Action<? super Compose> action) {
-        Compose compose = getCompose();
-        compose.getEnabled().set(true);
-        action.execute(compose);
+        action.execute(getCompose());
     }
 
     @Nested
@@ -80,9 +76,7 @@ public interface AndroidSoftware extends HasLinting {
 
     @Configuring
     default void coreLibraryDesugaring(Action<? super CoreLibraryDesugaring> action) {
-        CoreLibraryDesugaring coreLibraryDesugaring = getCoreLibraryDesugaring();
-        coreLibraryDesugaring.getEnabled().set(true);
-        action.execute(coreLibraryDesugaring);
+        action.execute(getCoreLibraryDesugaring());
     }
 
     @Nested
@@ -90,9 +84,7 @@ public interface AndroidSoftware extends HasLinting {
 
     @Configuring
     default void hilt(Action<? super Hilt> action) {
-        Hilt hilt = getHilt();
-        hilt.getEnabled().set(true);
-        action.execute(hilt);
+        action.execute(getHilt());
     }
 
     @Nested
@@ -100,9 +92,7 @@ public interface AndroidSoftware extends HasLinting {
 
     @Configuring
     default void room(Action<? super Room> action) {
-        Room room = getRoom();
-        room.getEnabled().set(true);
-        action.execute(room);
+        action.execute(getRoom());
     }
 
     @Nested
@@ -122,9 +112,7 @@ public interface AndroidSoftware extends HasLinting {
 
     @Configuring
     default void feature(Action<? super Feature> action) {
-        Feature feature = getFeature();
-        feature.getEnabled().set(true);
-        action.execute(feature);
+        action.execute(getFeature());
     }
 
     /**
@@ -136,9 +124,7 @@ public interface AndroidSoftware extends HasLinting {
 
     @Configuring
     default void licenses(Action<? super Licenses> action) {
-        Licenses licenses = getLicenses();
-        licenses.getEnabled().set(true);
-        action.execute(licenses);
+        action.execute(getLicenses());
     }
 
     @Nested
@@ -146,9 +132,7 @@ public interface AndroidSoftware extends HasLinting {
 
     @Configuring
     default void baselineProfile(Action<? super BaselineProfile> action) {
-        BaselineProfile baselineProfile = getBaselineProfile();
-        baselineProfile.getEnabled().set(true);
-        action.execute(baselineProfile);
+        action.execute(getBaselineProfile());
     }
 
     @Override
@@ -157,8 +141,6 @@ public interface AndroidSoftware extends HasLinting {
 
     @Configuring
     default void lint(Action<? super Lint> action) {
-        Lint lint = getLint();
-        lint.getEnabled().set(true);
-        action.execute(lint);
+        action.execute(getLint());
     }
 }

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/AndroidSoftwareBuildType.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/AndroidSoftwareBuildType.java
@@ -56,8 +56,6 @@ public interface AndroidSoftwareBuildType {
 
     @Configuring
     default void baselineProfile(Action<? super BaselineProfile> action) {
-        BaselineProfile baselineProfile = getBaselineProfile();
-        baselineProfile.getEnabled().set(true);
-        action.execute(baselineProfile);
+        action.execute(getBaselineProfile());
     }
 }

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/application/AndroidApplication.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/application/AndroidApplication.java
@@ -71,9 +71,7 @@ public interface AndroidApplication extends AndroidSoftware {
 
     @Configuring
     default void dependencyGuard(Action<? super DependencyGuard> action) {
-        DependencyGuard dependencyGuard = getDependencyGuard();
-        dependencyGuard.getEnabled().set(true);
-        action.execute(dependencyGuard);
+        action.execute(getDependencyGuard());
     }
 
     @Nested
@@ -81,9 +79,7 @@ public interface AndroidApplication extends AndroidSoftware {
 
     @Configuring
     default void firebase(Action<? super Firebase> action) {
-        Firebase firebase = getFirebase();
-        firebase.getEnabled().set(true);
-        action.execute(firebase);
+        action.execute(getFirebase());
     }
 
     @Nested
@@ -91,9 +87,7 @@ public interface AndroidApplication extends AndroidSoftware {
 
     @Configuring
     default void flavors(Action<? super Flavors> action) {
-        Flavors flavors = getFlavors();
-        flavors.getEnabled().set(true);
-        action.execute(flavors);
+        action.execute(getFlavors());
     }
 
     @Nested

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/extensions/BaselineProfile.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/extensions/BaselineProfile.java
@@ -22,10 +22,9 @@ import org.gradle.api.tasks.Nested;
 import org.gradle.declarative.dsl.model.annotations.Configuring;
 import org.gradle.declarative.dsl.model.annotations.Restricted;
 
+@Restricted
 public interface BaselineProfile {
-    /**
-     * Internal property purposely not exposed to the DSL.
-     */
+    @Restricted
     Property<Boolean> getEnabled();
 
     @Restricted

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/extensions/Licenses.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/extensions/Licenses.java
@@ -21,8 +21,6 @@ import org.gradle.declarative.dsl.model.annotations.Restricted;
 
 @Restricted
 public interface Licenses {
-    /**
-     * Internal property purposely not exposed to the DSL.
-     */
+    @Restricted
     Property<Boolean> getEnabled();
 }

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/extensions/testing/Testing.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/extensions/testing/Testing.java
@@ -15,9 +15,7 @@ public interface Testing {
 
     @Configuring
     default void jacoco(Action<? super Jacoco> action) {
-        Jacoco jacoco = getJacoco();
-        action.execute(jacoco);
-        jacoco.getEnabled().set(true);
+        action.execute(getJacoco());
     }
 
     @Nested
@@ -25,9 +23,7 @@ public interface Testing {
 
     @Configuring
     default void roborazzi(Action<? super Roborazzi> action) {
-        Roborazzi roborazzi = getRoborazzi();
-        roborazzi.getEnabled().set(true);
-        action.execute(roborazzi);
+        action.execute(getRoborazzi());
     }
 
     @Nested

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/library/AndroidLibrary.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/library/AndroidLibrary.java
@@ -53,8 +53,6 @@ public interface AndroidLibrary extends AndroidSoftware {
 
     @Configuring
     default void protobuf(Action<? super Protobuf> action) {
-        Protobuf protobuf = getProtobuf();
-        protobuf.getEnabled().set(true);
-        action.execute(protobuf);
+        action.execute(getProtobuf());
     }
 }

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/nia/Feature.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/nia/Feature.java
@@ -8,8 +8,6 @@ import org.gradle.declarative.dsl.model.annotations.Restricted;
  */
 @Restricted
 public interface Feature {
-    /**
-     * Internal property purposely not exposed to the DSL.
-     */
+    @Restricted
     Property<Boolean> getEnabled();
 }

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/nia/Flavors.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/nia/Flavors.java
@@ -21,8 +21,6 @@ import org.gradle.declarative.dsl.model.annotations.Restricted;
 
 @Restricted
 public interface Flavors {
-    /**
-     * Internal property purposely not exposed to the DSL.
-     */
+    @Restricted
     Property<Boolean> getEnabled();
 }

--- a/unified-prototype/unified-plugin/plugin-common/src/main/java/org/gradle/api/experimental/common/extensions/Lint.java
+++ b/unified-prototype/unified-plugin/plugin-common/src/main/java/org/gradle/api/experimental/common/extensions/Lint.java
@@ -21,9 +21,7 @@ import org.gradle.declarative.dsl.model.annotations.Restricted;
 
 @Restricted
 public interface Lint {
-    /**
-     * Internal property purposely not exposed to the DSL.
-     */
+    @Restricted
     Property<Boolean> getEnabled();
 
     @Restricted

--- a/unified-prototype/unified-plugin/plugin-kmp/src/main/java/org/gradle/api/experimental/kotlin/KotlinJvmLibrary.java
+++ b/unified-prototype/unified-plugin/plugin-kmp/src/main/java/org/gradle/api/experimental/kotlin/KotlinJvmLibrary.java
@@ -21,9 +21,7 @@ public interface KotlinJvmLibrary extends HasJavaTarget, HasLibraryDependencies,
 
     @Configuring
     default void lint(Action<? super Lint> action) {
-        Lint lint = getLint();
-        lint.getEnabled().set(true);
-        action.execute(lint);
+        action.execute(getLint());
     }
 
     @Nested


### PR DESCRIPTION
- Removes auto-enable logic from @Configuring methods and makes all enabled flags @Restricted.
- Also adds simple integration test to demonstrate extension convention behavior.