### PR TITLE
Fix default Markdown nested list indenting

### DIFF
--- a/.devcontainer/requirements.txt
+++ b/.devcontainer/requirements.txt
@@ -18,6 +18,7 @@ click==8.1.7
 dacite==1.8.1
 ghp-import==2.1.0
 jinja2==3.1.2
+mdx_truly_sane_lists==1.3
 mypy-extensions==1.0.0
 packaging==23.2
 pathspec==0.11.2

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -145,3 +145,4 @@ markdown_extensions:
   - toc:
       permalink: '#'
   - attr_list
+  - mdx_truly_sane_lists


### PR DESCRIPTION
Applies a fix for Python Markdown defaults so that we follow the GitHub Flavoured Markdown. https://github.com/Python-Markdown/markdown/issues/3