### PR TITLE
Explicitly add software type model objects to extensions

### DIFF
--- a/unified-prototype/gradle/wrapper/gradle-wrapper.properties
+++ b/unified-prototype/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-8.10-20240614182247+0000-bin.zip
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-8.10-20240627001704+0000-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/application/StandaloneAndroidApplicationPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/application/StandaloneAndroidApplicationPlugin.java
@@ -1,10 +1,7 @@
 package org.gradle.api.experimental.android.application;
 
-import com.android.build.api.attributes.ProductFlavorAttr;
 import com.android.build.api.dsl.ApplicationExtension;
 import org.gradle.api.Project;
-import org.gradle.api.attributes.Attribute;
-import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.experimental.android.AbstractAndroidSoftwarePlugin;
 import org.gradle.api.experimental.android.AndroidSoftware;
 import org.gradle.api.experimental.android.nia.NiaSupport;
@@ -18,7 +15,10 @@ import static org.gradle.api.experimental.android.AndroidSupport.ifPresent;
  */
 @SuppressWarnings("UnstableApiUsage")
 public abstract class StandaloneAndroidApplicationPlugin extends AbstractAndroidSoftwarePlugin {
-    @SoftwareType(name = "androidApplication", modelPublicType=AndroidApplication.class)
+
+    public static final String ANDROID_APPLICATION = "androidApplication";
+
+    @SoftwareType(name = ANDROID_APPLICATION, modelPublicType=AndroidApplication.class)
     public abstract AndroidApplication getAndroidApplication();
 
     @Override
@@ -31,6 +31,7 @@ public abstract class StandaloneAndroidApplicationPlugin extends AbstractAndroid
         super.apply(project);
 
         AndroidApplication dslModel = getAndroidApplication();
+        project.getExtensions().add(ANDROID_APPLICATION, dslModel);
 
         // Setup application-specific conventions
         dslModel.getDependencyGuard().getEnabled().convention(false);

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/library/StandaloneAndroidLibraryPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/library/StandaloneAndroidLibraryPlugin.java
@@ -25,7 +25,10 @@ import static org.gradle.api.experimental.android.AndroidSupport.ifPresent;
  */
 @SuppressWarnings("UnstableApiUsage")
 public abstract class StandaloneAndroidLibraryPlugin extends AbstractAndroidSoftwarePlugin {
-    @SoftwareType(name = "androidLibrary", modelPublicType=AndroidLibrary.class)
+
+    public static final String ANDROID_LIBRARY = "androidLibrary";
+
+    @SoftwareType(name = ANDROID_LIBRARY, modelPublicType=AndroidLibrary.class)
     public abstract AndroidLibrary getAndroidLibrary();
 
     @Override
@@ -38,6 +41,7 @@ public abstract class StandaloneAndroidLibraryPlugin extends AbstractAndroidSoft
         super.apply(project);
 
         AndroidLibrary dslModel = getAndroidLibrary();
+        project.getExtensions().add(ANDROID_LIBRARY, dslModel);
 
         // Setup library-specific conventions
         dslModel.getProtobuf().getEnabled().convention(false);

--- a/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/java/StandaloneJavaApplicationPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/java/StandaloneJavaApplicationPlugin.java
@@ -12,12 +12,16 @@ import org.gradle.api.plugins.ApplicationPlugin;
  * and links the declarative model to the official plugin.
  */
 abstract public class StandaloneJavaApplicationPlugin implements Plugin<Project> {
-    @SoftwareType(name = "javaApplication", modelPublicType = JavaApplication.class)
+
+    public static final String JAVA_APPLICATION = "javaApplication";
+
+    @SoftwareType(name = JAVA_APPLICATION, modelPublicType = JavaApplication.class)
     abstract public JavaApplication getApplication();
 
     @Override
     public void apply(Project project) {
         JavaApplication dslModel = getApplication();
+        project.getExtensions().add(JAVA_APPLICATION, dslModel);
 
         project.getPlugins().apply(ApplicationPlugin.class);
         project.getPlugins().apply(CliApplicationConventionsPlugin.class);

--- a/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/java/StandaloneJavaLibraryPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/java/StandaloneJavaLibraryPlugin.java
@@ -11,12 +11,15 @@ import org.gradle.api.plugins.JavaLibraryPlugin;
  * and links the declarative model to the official plugin.
  */
 public abstract class StandaloneJavaLibraryPlugin implements Plugin<Project> {
-    @SoftwareType(name = "javaLibrary", modelPublicType = JavaLibrary.class)
+    public static final String JAVA_LIBRARY = "javaLibrary";
+
+    @SoftwareType(name = JAVA_LIBRARY, modelPublicType = JavaLibrary.class)
     abstract public JavaLibrary getLibrary();
 
     @Override
     public void apply(Project project) {
         JavaLibrary dslModel = getLibrary();
+        project.getExtensions().add(JAVA_LIBRARY, dslModel);
 
         project.getPlugins().apply(JavaLibraryPlugin.class);
 

--- a/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/jvm/StandaloneJvmApplicationPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/jvm/StandaloneJvmApplicationPlugin.java
@@ -18,12 +18,16 @@ import javax.inject.Inject;
  * and links the declarative model to the official plugin.
  */
 abstract public class StandaloneJvmApplicationPlugin implements Plugin<Project> {
-    @SoftwareType(name = "jvmApplication", modelPublicType = JvmApplication.class)
+
+    public static final String JVM_APPLICATION = "jvmApplication";
+
+    @SoftwareType(name = JVM_APPLICATION, modelPublicType = JvmApplication.class)
     abstract public JvmApplication getJvmApplication();
 
     @Override
     public void apply(Project project) {
         JvmApplication dslModel = getJvmApplication();
+        project.getExtensions().add(JVM_APPLICATION, dslModel);
 
         project.getPlugins().apply(ApplicationPlugin.class);
         project.getPlugins().apply(CliApplicationConventionsPlugin.class);

--- a/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/jvm/StandaloneJvmLibraryPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/jvm/StandaloneJvmLibraryPlugin.java
@@ -15,12 +15,16 @@ import javax.inject.Inject;
  * and links the declarative model to the official plugin.
  */
 abstract public class StandaloneJvmLibraryPlugin implements Plugin<Project> {
-    @SoftwareType(name = "jvmLibrary", modelPublicType = JvmLibrary.class)
+
+    public static final String JVM_LIBRARY = "jvmLibrary";
+
+    @SoftwareType(name = JVM_LIBRARY, modelPublicType = JvmLibrary.class)
     abstract public JvmLibrary getJvmLibrary();
 
     @Override
     public void apply(Project project) {
         JvmLibrary dslModel = getJvmLibrary();
+        project.getExtensions().add(JVM_LIBRARY, dslModel);
 
         project.getPlugins().apply(JavaLibraryPlugin.class);
 

--- a/unified-prototype/unified-plugin/plugin-kmp/src/main/java/org/gradle/api/experimental/kmp/StandaloneKmpApplicationPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-kmp/src/main/java/org/gradle/api/experimental/kmp/StandaloneKmpApplicationPlugin.java
@@ -18,12 +18,16 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension;
  * and links the declarative model to the official plugin.
  */
 abstract public class StandaloneKmpApplicationPlugin implements Plugin<Project> {
-    @SoftwareType(name = "kotlinApplication", modelPublicType = KmpApplication.class)
+
+    public static final String KOTLIN_APPLICATION = "kotlinApplication";
+
+    @SoftwareType(name = KOTLIN_APPLICATION, modelPublicType = KmpApplication.class)
     abstract public KmpApplication getKmpApplication();
 
     @Override
     public void apply(Project project) {
         KmpApplication dslModel = createDslModel(project);
+        project.getExtensions().add(KOTLIN_APPLICATION, dslModel);
 
         project.afterEvaluate(p -> linkDslModelToPlugin(p, dslModel));
 

--- a/unified-prototype/unified-plugin/plugin-kmp/src/main/java/org/gradle/api/experimental/kmp/StandaloneKmpLibraryPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-kmp/src/main/java/org/gradle/api/experimental/kmp/StandaloneKmpLibraryPlugin.java
@@ -14,12 +14,16 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension;
  * and links the declarative model to the official plugin.
  */
 abstract public class StandaloneKmpLibraryPlugin implements Plugin<Project> {
-    @SoftwareType(name = "kotlinLibrary", modelPublicType = KmpLibrary.class)
+
+    public static final String KOTLIN_LIBRARY = "kotlinLibrary";
+
+    @SoftwareType(name = KOTLIN_LIBRARY, modelPublicType = KmpLibrary.class)
     abstract public KmpLibrary getKmpLibrary();
 
     @Override
     public void apply(Project project) {
         KmpLibrary dslModel = createDslModel(project);
+        project.getExtensions().add(KOTLIN_LIBRARY, dslModel);
 
         project.afterEvaluate(p -> linkDslModelToPlugin(p, dslModel));
 

--- a/unified-prototype/unified-plugin/plugin-kmp/src/main/java/org/gradle/api/experimental/kotlin/StandaloneKotlinJvmApplicationPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-kmp/src/main/java/org/gradle/api/experimental/kotlin/StandaloneKotlinJvmApplicationPlugin.java
@@ -13,12 +13,16 @@ import org.gradle.api.plugins.ApplicationPlugin;
  * and links the declarative model to the official plugin.
  */
 abstract public class StandaloneKotlinJvmApplicationPlugin implements Plugin<Project> {
-    @SoftwareType(name = "kotlinJvmApplication", modelPublicType = KotlinJvmApplication.class)
+
+    public static final String KOTLIN_JVM_APPLICATION = "kotlinJvmApplication";
+
+    @SoftwareType(name = KOTLIN_JVM_APPLICATION, modelPublicType = KotlinJvmApplication.class)
     abstract public KotlinJvmApplication getApplication();
 
     @Override
     public void apply(Project project) {
         KotlinJvmApplication dslModel = getApplication();
+        project.getExtensions().add(KOTLIN_JVM_APPLICATION, dslModel);
 
         project.getPlugins().apply(ApplicationPlugin.class);
         project.getPlugins().apply("org.jetbrains.kotlin.jvm");

--- a/unified-prototype/unified-plugin/plugin-kmp/src/main/java/org/gradle/api/experimental/kotlin/StandaloneKotlinJvmLibraryPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-kmp/src/main/java/org/gradle/api/experimental/kotlin/StandaloneKotlinJvmLibraryPlugin.java
@@ -14,12 +14,16 @@ import org.gradle.api.internal.plugins.software.SoftwareType;
  */
 @SuppressWarnings("UnstableApiUsage")
 abstract public class StandaloneKotlinJvmLibraryPlugin implements Plugin<Project> {
-    @SoftwareType(name = "kotlinJvmLibrary", modelPublicType = KotlinJvmLibrary.class)
+
+    public static final String KOTLIN_JVM_LIBRARY = "kotlinJvmLibrary";
+
+    @SoftwareType(name = KOTLIN_JVM_LIBRARY, modelPublicType = KotlinJvmLibrary.class)
     abstract public KotlinJvmLibrary getLibrary();
 
     @Override
     public void apply(Project project) {
         KotlinJvmLibrary dslModel = getLibrary();
+        project.getExtensions().add(KOTLIN_JVM_LIBRARY, dslModel);
 
         project.getPlugins().apply("org.jetbrains.kotlin.jvm");
 

--- a/unified-prototype/unified-plugin/plugin-swift/src/main/java/org/gradle/api/experimental/swift/StandaloneSwiftApplicationPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-swift/src/main/java/org/gradle/api/experimental/swift/StandaloneSwiftApplicationPlugin.java
@@ -16,12 +16,16 @@ import org.gradle.language.swift.plugins.SwiftApplicationPlugin;
 import org.gradle.util.internal.TextUtil;
 
 public abstract class StandaloneSwiftApplicationPlugin implements Plugin<Project> {
-    @SoftwareType(name = "swiftApplication", modelPublicType = SwiftApplication.class)
+
+    public static final String SWIFT_APPLICATION = "swiftApplication";
+
+    @SoftwareType(name = SWIFT_APPLICATION, modelPublicType = SwiftApplication.class)
     abstract public SwiftApplication getApplication();
 
     @Override
     public void apply(Project project) {
         SwiftApplication application = getApplication();
+        project.getExtensions().add(SWIFT_APPLICATION, application);
 
         project.getPlugins().apply(SwiftApplicationPlugin.class);
         project.getPlugins().apply(CliApplicationConventionsPlugin.class);

--- a/unified-prototype/unified-plugin/plugin-swift/src/main/java/org/gradle/api/experimental/swift/StandaloneSwiftLibraryPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-swift/src/main/java/org/gradle/api/experimental/swift/StandaloneSwiftLibraryPlugin.java
@@ -7,12 +7,16 @@ import org.gradle.api.internal.plugins.software.SoftwareType;
 import org.gradle.language.swift.plugins.SwiftLibraryPlugin;
 
 public abstract class StandaloneSwiftLibraryPlugin implements Plugin<Project> {
-    @SoftwareType(name = "swiftLibrary", modelPublicType = SwiftLibrary.class)
+
+    public static final String SWIFT_LIBRARY = "swiftLibrary";
+
+    @SoftwareType(name = SWIFT_LIBRARY, modelPublicType = SwiftLibrary.class)
     abstract public SwiftLibrary getLibrary();
 
     @Override
     public void apply(Project project) {
         SwiftLibrary library = getLibrary();
+        project.getExtensions().add(SWIFT_LIBRARY, library);
 
         project.getPlugins().apply(SwiftLibraryPlugin.class);
 


### PR DESCRIPTION
As a follow up to https://github.com/gradle/gradle/pull/29648, this changes each prototype plugin to explicitly register the software type model object as a project extension.