### PR TITLE
Update wrapper to latest Gradle nightly

### DIFF
--- a/unified-prototype/gradle/wrapper/gradle-wrapper.properties
+++ b/unified-prototype/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-8.10-20240627001704+0000-bin.zip
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-8.10-20240703002818+0000-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
The latest nightly includes support for applying build level conventions for software types in non-declarative scripts that apply software type plugins.