### PR TITLE
Update wrapper and rename conventions -> defaults

### DIFF
--- a/docs/reference/software-features.md
+++ b/docs/reference/software-features.md
@@ -42,12 +42,12 @@ In the future, additional types of software features will be added to Declarativ
 
 ## Shared Model Defaults
 
-Shared Model Defaults are collections of settings that are applied to all projects in a build that use a given software type.  They are shared across all projects in a build.  These are declared by referencing the software type in the `conventions` block in the declarative settings file.
+Shared Model Defaults are collections of settings that are applied to all projects in a build that use a given software type.  They are shared across all projects in a build.  These are declared by referencing the software type in the `defaults` block in the declarative settings file.
 
 For example, to declare that all projects that produce Java libraries should produce a library built for Java 11, the `javaLibrary` software type is configured in `settings.gradle.dcl`:
 
 ```kotlin
-conventions {
+defaults {
     javaLibrary {
         javaVersion = 11
     }

--- a/unified-prototype/gradle/wrapper/gradle-wrapper.properties
+++ b/unified-prototype/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-8.10-20240703002818+0000-bin.zip
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-8.10-20240719001820+0000-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/unified-prototype/settings.gradle.dcl
+++ b/unified-prototype/settings.gradle.dcl
@@ -24,7 +24,7 @@ dependencyResolutionManagement {
 
 rootProject.name = "unified-prototype"
 
-conventions {
+defaults {
     androidLibrary {
         jdkVersion = 11
         compileSdk = 34

--- a/unified-prototype/unified-plugin/plugin-android/src/integTest/groovy/org/gradle/api/experimental/android/AndroidLibrarySpec.groovy
+++ b/unified-prototype/unified-plugin/plugin-android/src/integTest/groovy/org/gradle/api/experimental/android/AndroidLibrarySpec.groovy
@@ -27,7 +27,7 @@ class AndroidLibrarySpec extends AbstractSpecification {
         """
 
         settingsFile << """
-            conventions {
+            defaults {
                 androidLibrary {
                     jdkVersion = 17
                     compileSdk = 34
@@ -58,7 +58,7 @@ class AndroidLibrarySpec extends AbstractSpecification {
         """
 
         settingsFile << """
-            conventions {
+            defaults {
                 androidLibrary {
                     jdkVersion = 17
                     compileSdk = 34
@@ -99,7 +99,7 @@ class AndroidLibrarySpec extends AbstractSpecification {
         """
 
         settingsFile << """
-            conventions {
+            defaults {
                 androidLibrary {
                     jdkVersion = 17
                     compileSdk = 34


### PR DESCRIPTION
Updates to the latest nightly and handles the rename of `conventions { }` to `defaults { }`.