### PR TITLE
Update to use Gradle 8.10

### DIFF
--- a/unified-prototype/gradle/wrapper/gradle-wrapper.properties
+++ b/unified-prototype/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-8.11-20240815222552+0000-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/unified-prototype/unified-plugin/gradle/libs.versions.toml
+++ b/unified-prototype/unified-plugin/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
 # Kotlin Libs
 # Find latest version at: https://kotlinlang.org/docs/releases.html#release-details
-kotlin = "1.9.23"
-ksp = "1.9.23-1.0.20"
+kotlin = "1.9.24"
+ksp = "1.9.24-1.0.20"
 
 # Android Libs
 # Find latest version at: https://developer.android.com/reference/tools/gradle-api

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/buildinit/AndroidProjectSource.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/buildinit/AndroidProjectSource.java
@@ -1,25 +1,5 @@
 package org.gradle.api.experimental.buildinit;
 
-import org.gradle.buildinit.projectspecs.InitProjectGenerator;
-import org.gradle.buildinit.projectspecs.InitProjectSource;
-import org.gradle.buildinit.projectspecs.InitProjectSpec;
-
-import java.util.List;
-
-/**
- * A {@link InitProjectSource} of project specifications for Android projects.
- */
-@SuppressWarnings("UnstableApiUsage")
-public final class AndroidProjectSource implements InitProjectSource {
-    @Override
-    public List<InitProjectSpec> getProjectSpecs() {
-        return List.of(
-            new StaticProjectSpec("android-application", "Declarative Android Application Project")
-        );
-    }
-
-    @Override
-    public Class<? extends InitProjectGenerator> getProjectGenerator() {
-        return StaticProjectGenerator.class;
-    }
+public final class AndroidProjectSource {
+    // TODO: Restore this after updating to Gradle 8.11
 }

--- a/unified-prototype/unified-plugin/plugin-android/src/main/resources/templates/android-application/README.md
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/resources/templates/android-application/README.md
@@ -3,7 +3,7 @@ A sample Android application written in the Declarative Gradle DSL, using the pr
 
 ## Building and Running
 
-This sample shows the definition of a multiproject Android application implemented using Kotlin 1.9.23 source code.
+This sample shows the definition of a multiproject Android application implemented using Kotlin 1.9.24 source code.
 The project is the result of reproducing the project produced by the `gradle init` command in Gradle 8.9 as an Android project.
 
 To build the project without running, use:

--- a/unified-prototype/unified-plugin/plugin-common/src/main/java/org/gradle/api/experimental/buildinit/StaticProjectGenerator.java
+++ b/unified-prototype/unified-plugin/plugin-common/src/main/java/org/gradle/api/experimental/buildinit/StaticProjectGenerator.java
@@ -1,31 +1,5 @@
 package org.gradle.api.experimental.buildinit;
 
-import org.gradle.api.file.Directory;
-import org.gradle.buildinit.projectspecs.InitProjectConfig;
-import org.gradle.buildinit.projectspecs.InitProjectGenerator;
-import org.gradle.util.ResourceLoader;
-
-/**
- * An {@link InitProjectGenerator} that generates a project from a static template packaged
- * as resources files in the {@link #TEMPLATES_ROOT} directory.
- */
-@SuppressWarnings("UnstableApiUsage")
-public abstract class StaticProjectGenerator implements InitProjectGenerator {
-    private static final String TEMPLATES_ROOT = "templates";
-
-    @Override
-    public void generate(InitProjectConfig config, Directory projectDir) {
-        if (!(config.getProjectSpec() instanceof StaticProjectSpec projectSpec)) {
-            throw new IllegalArgumentException("Unknown project type: " + config.getProjectSpec().getDisplayName() + " (" + config.getProjectSpec().getClass().getName() + ")");
-        }
-
-        String templatePath = TEMPLATES_ROOT + "/" + projectSpec.getTemplatePath();
-        ResourceLoader resourceLoader = new ResourceLoader();
-
-        try {
-            resourceLoader.extractDirectoryFromResources(templatePath, projectDir.getAsFile());
-        } catch (Exception e) {
-            throw new RuntimeException("Error extracting resources for: '" + projectSpec.getDisplayName() + "' from: '" + templatePath + "'!", e);
-        }
-    }
+public abstract class StaticProjectGenerator {
+    // TODO: Restore this after updating to Gradle 8.11
 }

--- a/unified-prototype/unified-plugin/plugin-common/src/main/java/org/gradle/api/experimental/buildinit/StaticProjectSpec.java
+++ b/unified-prototype/unified-plugin/plugin-common/src/main/java/org/gradle/api/experimental/buildinit/StaticProjectSpec.java
@@ -1,36 +1,5 @@
 package org.gradle.api.experimental.buildinit;
 
-import org.gradle.buildinit.projectspecs.InitProjectParameter;
-import org.gradle.buildinit.projectspecs.InitProjectSpec;
-
-import java.util.Collections;
-import java.util.List;
-
-/**
- * An {@link InitProjectSpec} that represents a project that can be generated from a static template
- * using the {@link StaticProjectGenerator}
- */
-@SuppressWarnings("UnstableApiUsage")
-public final class StaticProjectSpec implements InitProjectSpec {
-    private final String templatePath;
-    private final String displayName;
-
-    public StaticProjectSpec(String templatePath, String displayName) {
-        this.templatePath = templatePath;
-        this.displayName = displayName;
-    }
-
-    @Override
-    public String getDisplayName() {
-        return displayName;
-    }
-
-    @Override
-    public List<InitProjectParameter<?>> getParameters() {
-        return Collections.emptyList();
-    }
-
-    public String getTemplatePath() {
-        return templatePath;
-    }
+public final class StaticProjectSpec {
+    // TODO: Restore this after updating to Gradle 8.11
 }

--- a/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/buildinit/JVMProjectSource.java
+++ b/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/buildinit/JVMProjectSource.java
@@ -1,25 +1,5 @@
 package org.gradle.api.experimental.buildinit;
 
-import java.util.List;
-
-import org.gradle.buildinit.projectspecs.InitProjectGenerator;
-import org.gradle.buildinit.projectspecs.InitProjectSpec;
-import org.gradle.buildinit.projectspecs.InitProjectSource;
-
-/**
- * A {@link InitProjectSource} of project specifications for JVM projects.
- */
-@SuppressWarnings("UnstableApiUsage")
-public final class JVMProjectSource implements InitProjectSource {
-    @Override
-    public List<InitProjectSpec> getProjectSpecs() {
-        return List.of(
-            new StaticProjectSpec("java-application", "Declarative Java Application Project")
-        );
-    }
-
-    @Override
-    public Class<? extends InitProjectGenerator> getProjectGenerator() {
-        return StaticProjectGenerator.class;
-    }
+public final class JVMProjectSource {
+    // TODO: Restore this after updating to Gradle 8.11
 }

--- a/unified-prototype/unified-plugin/plugin-kmp/src/main/java/org/gradle/api/experimental/buildinit/KMPProjectSource.java
+++ b/unified-prototype/unified-plugin/plugin-kmp/src/main/java/org/gradle/api/experimental/buildinit/KMPProjectSource.java
@@ -1,25 +1,5 @@
 package org.gradle.api.experimental.buildinit;
 
-import org.gradle.buildinit.projectspecs.InitProjectGenerator;
-import org.gradle.buildinit.projectspecs.InitProjectSource;
-import org.gradle.buildinit.projectspecs.InitProjectSpec;
-
-import java.util.List;
-
-/**
- * A {@link InitProjectSource} of project specifications for Kotlin (JVM) projects.
- */
-@SuppressWarnings("UnstableApiUsage")
-public final class KMPProjectSource implements InitProjectSource{
-    @Override
-    public List<InitProjectSpec> getProjectSpecs() {
-        return List.of(
-            new StaticProjectSpec("kotlin-application", "Declarative Kotlin (JVM) Application Project")
-        );
-    }
-
-    @Override
-    public Class<? extends InitProjectGenerator> getProjectGenerator() {
-        return StaticProjectGenerator.class;
-    }
+public final class KMPProjectSource {
+    // TODO: Restore this after updating to Gradle 8.11
 }

--- a/unified-prototype/unified-plugin/plugin-kmp/src/main/resources/templates/kotlin-application/README.md
+++ b/unified-prototype/unified-plugin/plugin-kmp/src/main/resources/templates/kotlin-application/README.md
@@ -3,7 +3,7 @@ A sample Kotlin application written in the Declarative Gradle DSL, using the pro
 
 ## Building and Running
 
-This sample shows the definition of a Kotlin JVM application implemented using Kotlin 1.9.23 source code.
+This sample shows the definition of a Kotlin JVM application implemented using Kotlin 1.9.24 source code.
 The project is the result of converting the project produced by the `gradle init` command in Gradle 8.9.
 
 To build and test the application without running, use:


### PR DESCRIPTION
- This (temporarily) removes the init template generation code until a non-nightly Gradle 8.11 is released that contains it.
- It also updates kotlin to 1.9.24 to avoid build warnings about mismatched embedded versions.