### PR TITLE
Don't apply init plugin automatically from ecosystem plugin

### DIFF
--- a/unified-prototype/unified-plugin/plugin-android-init/build.gradle.kts
+++ b/unified-prototype/unified-plugin/plugin-android-init/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     groovy // For spock testing
 }
 
-description = "Implements the build init for Android"
+description = "Provides Build Init Specs for Android projects"
 
 dependencies {
     api(project(":plugin-common"))
@@ -33,8 +33,8 @@ gradlePlugin {
     plugins {
         create("android-init") {
             id = "org.gradle.experimental.android-ecosystem-init"
-            displayName = "Android Experimental Init Plugin"
-            description = "Experimental init plugin for the Android ecosystem"
+            displayName = "Android Experimental Build Init Plugin"
+            description = "Experimental build init plugin contribuing build types for the Android ecosystem"
             implementationClass = "org.gradle.api.experimental.android.AndroidEcosystemInitPlugin"
             tags = setOf("declarative-gradle", "android", "init")
         }

--- a/unified-prototype/unified-plugin/plugin-android/build.gradle.kts
+++ b/unified-prototype/unified-plugin/plugin-android/build.gradle.kts
@@ -14,7 +14,6 @@ dependencies {
     api(libs.android.kotlin.android)
 
     implementation(project(":plugin-jvm"))
-    implementation(project(":plugin-android-init"))
     implementation(libs.baseline.profile.plugin)
     implementation(libs.dependency.guard.plugin)
     implementation(libs.ksp.plugin)

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/AndroidEcosystemPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/AndroidEcosystemPlugin.java
@@ -3,22 +3,18 @@ package org.gradle.api.experimental.android;
 import org.gradle.api.Plugin;
 import org.gradle.api.experimental.android.application.StandaloneAndroidApplicationPlugin;
 import org.gradle.api.experimental.android.library.StandaloneAndroidLibraryPlugin;
-import org.gradle.api.experimental.buildinit.StaticProjectGenerator;
-import org.gradle.api.experimental.buildinit.StaticProjectSpec;
 import org.gradle.api.experimental.jvm.JvmEcosystemConventionsPlugin;
 import org.gradle.api.initialization.Settings;
 import org.gradle.api.internal.plugins.software.RegistersSoftwareTypes;
 import org.gradle.buildinit.specs.internal.BuildInitSpecRegistry;
 
 import javax.inject.Inject;
-import java.util.List;
 
 @SuppressWarnings("UnstableApiUsage")
 @RegistersSoftwareTypes({StandaloneAndroidApplicationPlugin.class, StandaloneAndroidLibraryPlugin.class})
 public abstract class AndroidEcosystemPlugin implements Plugin<Settings> {
     @Override
     public void apply(Settings target) {
-        target.getPlugins().apply("org.gradle.experimental.android-ecosystem-init");
         target.getPlugins().apply(JvmEcosystemConventionsPlugin.class);
         target.getDependencyResolutionManagement().getRepositories().google();
     }


### PR DESCRIPTION
It doesn't seem necessary to apply the init plugin if you already have an android ecosystem project that is applying the ecosystem plugin.