### PR TITLE
Add IntelliJ IDEA to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The project includes the following experimental parts:
 
 - Software Types as a declarative modeling framework
 - Changes in Gradle to support DCL files
-- Changes in Android Studio to support DCL files
+- Changes in Android Studio and IntelliJ IDEA to support DCL files
 - A Visual Studio Code extension to support DCL files
 - An Eclipse IDE plugin to support DCL files
 - Prototype plugins demonstrating software types and higher-level models

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -41,6 +41,7 @@ To discuss the roadmap and the related initiatives, use the
   * Named domain object containers
 * Configuring Software Types from Kotlin DSL
 * Prototype Plugins for C++ and Swift
+* IntelliJ IDEA DCL support preview
 * Support for VS Code and Eclipse IDE
 * Generating Declarative Builds with `gradle init`
 

--- a/docs/getting-started/features.md
+++ b/docs/getting-started/features.md
@@ -32,6 +32,8 @@ Code completion only suggests the properties and nested blocks available in the 
 
 This video demonstrates the enhanced support for DCL in Android Studio, covering enum properties and named domain object containers.
 
+The same level of support should be expected in [IntelliJ IDEA](./setup.md#intellij-idea).
+
 ### Visual Studio Code
 
 <script src="https://fast.wistia.com/embed/medias/8t8appyr68.jsonp" async></script>

--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -9,6 +9,7 @@ To try out the samples and see all of the features, you need to install a few ot
 - [JDK](#jdk)
 - [IDE](#ide)
   - [Android Studio](#android-studio)
+  - [IntelliJ IDEA](#intellij-idea)
   - [Visual Studio Code](#visual-studio-code)
   - [Eclipse IDE](#eclipse-ide)
 - [Gradle Client](#gradle-client)
@@ -44,6 +45,14 @@ While syntax highlighting of `.gradle.dcl` files works out of the box in Studio 
 1. Search for the Declarative Gradle flags by typing `declarative`
 2. Enable the `gradle.declarative.studio.support` and `gradle.declarative.ide.support` flags
 3. Restart the IDE
+
+### IntelliJ IDEA
+
+Download and install a special IntelliJ IDEA Nightly release.
+You can find the promoted nightly releases in [this Google Drive folder](https://drive.google.com/drive/folders/19iWu2F4dYs0Vc9xFMkSwY7wizKk-YMKl19C5EMRgENKU_tOAwOVLcIGZ6Bbm63Q7V) for macOS (Apple Silicon and Intel), Windows and Linux.
+Pick the most recent one that matches your operating system.
+
+Follow the same instructions as with [Android Studio](#android-studio) above to enable Declarative features.
 
 ### Visual Studio Code
 

--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -49,7 +49,7 @@ While syntax highlighting of `.gradle.dcl` files works out of the box in Studio 
 ### IntelliJ IDEA
 
 Download and install a special IntelliJ IDEA Nightly release.
-You can find the promoted nightly releases in [this Google Drive folder](https://drive.google.com/drive/folders/19iWu2F4dYs0Vc9xFMkSwY7wizKk-YMKl19C5EMRgENKU_tOAwOVLcIGZ6Bbm63Q7V) for macOS (Apple Silicon and Intel), Windows and Linux.
+You can find the promoted nightly releases in [this Google Drive folder](https://drive.google.com/drive/folders/19iWu2F4dYs0Vc9xFMkSwY7wizKk-YMKl) for macOS (Apple Silicon and Intel), Windows and Linux.
 Pick the most recent one that matches your operating system.
 
 Follow the same instructions as with [Android Studio](#android-studio) above to enable Declarative features.


### PR DESCRIPTION
IntelliJ IDEA builds with DCL support are now available at
https://drive.google.com/drive/folders/19iWu2F4dYs0Vc9xFMkSwY7wizKk-YMKl
