### PR TITLE
Use AWS secret manager to store GitHub token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
       contents: write
       packages: read
       pull-requests: write
-      id-token: write
 
     env:
       PR_PATH: ${{ github.event.repository.name }}/pull/${{github.event.number}}
@@ -26,17 +25,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: "true"
-
-      - name: Configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::992382829881:role/GHASecrets_declarative-gradle_all
-          aws-region: "eu-central-1"
-      - name: Get secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@v2
-        with:
-          secret-ids: |
-            BOT_GRADLE_GITHUB_TOKEN, gha/declarative-gradle/_all/BOT_GRADLE_GITHUB_TOKEN
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -62,7 +50,7 @@ jobs:
         uses: hasura/comment-progress@v2.2.0
         if: github.ref != 'refs/heads/main'
         with:
-          github-token: ${{ env.BOT_GRADLE_GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}
           number: ${{ github.event.number }}
           id: deploy-preview

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -13,7 +13,6 @@ jobs:
 
     permissions:
       pull-requests: write
-      id-token: write
 
     steps:
       - name: make empty dir
@@ -27,21 +26,10 @@ jobs:
           publish_dir: ./public
           destination_dir: ${{ env.PR_PATH }}
 
-      - name: Configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::992382829881:role/GHASecrets_declarative-gradle_all
-          aws-region: "eu-central-1"
-      - name: Get secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@v2
-        with:
-          secret-ids: |
-            BOT_GRADLE_GITHUB_TOKEN, gha/declarative-gradle/_all/BOT_GRADLE_GITHUB_TOKEN
-
       - name: Comment on PR
         uses: hasura/comment-progress@v2.2.0
         with:
-          github-token: ${{ secrets.BOT_GRADLE_GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}
           number: ${{ github.event.number }}
           id: deploy-preview


### PR DESCRIPTION
The GitHub token is stored in Github secret and will expire in 2 months. It's a good oppotunity for us to migrate to AWS secret manager per [this doc](https://docs.google.com/document/d/1_rY5rmAIRaOK_fl-3z7CCt_gdIf3ZVwceYj34HMR5GY/edit?tab=t.0). In this way, we can manage/renew all secrets in AWS.