### PR TITLE
All wiring KMP application plugin to kmpApplication block instance without applying plugin

### DIFF
--- a/unified-prototype/unified-plugin/plugin-kmp/build.gradle.kts
+++ b/unified-prototype/unified-plugin/plugin-kmp/build.gradle.kts
@@ -9,7 +9,8 @@ plugins {
 description = "Implements the declarative KMP DSL prototype"
 
 dependencies {
-    implementation(project(":plugin-common"))
+    api(project(":plugin-common"))
+
     implementation(project(":plugin-jvm"))
     implementation(libs.kotlin.multiplatform)
     implementation(libs.kotlin.jvm)

--- a/unified-prototype/unified-plugin/plugin-kmp/src/main/java/org/gradle/api/experimental/kmp/StandaloneKmpApplicationPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-kmp/src/main/java/org/gradle/api/experimental/kmp/StandaloneKmpApplicationPlugin.java
@@ -33,13 +33,13 @@ public abstract class StandaloneKmpApplicationPlugin implements Plugin<Project> 
 
     @Override
     public void apply(Project project) {
-        PluginWiring.wirePlugin(project, getKmpApplication());
+        PluginWiring.wireKMPApplication(project, getKmpApplication());
     }
 
     public static final class PluginWiring {
         private PluginWiring() { /* not instantiable */ }
 
-        public static void wirePlugin(Project project, KmpApplication initialDslModel) {
+        public static void wireKMPApplication(Project project, KmpApplication initialDslModel) {
             KmpApplication dslModel = setupDslModel(project, initialDslModel);
 
             project.afterEvaluate(p -> linkDslModelToPlugin(p, dslModel));


### PR DESCRIPTION
This is currently necessary for custom SoftwareTypes to reuse kotlinApplication extention as an inner extension and wire it. 