### PR TITLE
Update init build specs in prototype; add check to verify version used remains curent

### DIFF
--- a/unified-prototype/unified-plugin/plugin-android-init/src/integTest/groovy/org/gradle/api/experimental/android/AndroidApplicationAgpPreview.groovy
+++ b/unified-prototype/unified-plugin/plugin-android-init/src/integTest/groovy/org/gradle/api/experimental/android/AndroidApplicationAgpPreview.groovy
@@ -1,8 +1,0 @@
-package org.gradle.api.experimental.android
-
-class AndroidApplicationAgpPreview extends AbstractAndroidBuildInitSpec {
-    @Override
-    protected String getProjectSpecType() {
-        return "android-application-agp-preview"
-    }
-}

--- a/unified-prototype/unified-plugin/plugin-android-init/src/integTest/groovy/org/gradle/api/experimental/android/AndroidApplicationAgpPreviewBuildInitSpec.groovy
+++ b/unified-prototype/unified-plugin/plugin-android-init/src/integTest/groovy/org/gradle/api/experimental/android/AndroidApplicationAgpPreviewBuildInitSpec.groovy
@@ -1,0 +1,13 @@
+package org.gradle.api.experimental.android
+
+class AndroidApplicationAgpPreviewBuildInitSpec extends AbstractAndroidBuildInitSpec {
+    @Override
+    protected String getProjectSpecType() {
+        return "android-application-agp-preview"
+    }
+
+    @Override
+    protected boolean shouldValidateLatestPublishedVersionUsedInSpec() {
+        return false // Specs using official AGP versions don't use the prototype plugins
+    }
+}

--- a/unified-prototype/unified-plugin/plugin-android-init/src/main/resources/templates/android-application-basic-activity/app/build.gradle.dcl
+++ b/unified-prototype/unified-plugin/plugin-android-init/src/main/resources/templates/android-application-basic-activity/app/build.gradle.dcl
@@ -23,12 +23,8 @@ androidApplication {
                 enabled = false
             }
 
-            defaultProguardFile {
-                name = "proguard-android-optimize.txt"
-            }
-            proguardFile {
-                name = "proguard-rules.pro"
-            }
+            defaultProguardFiles = listOf(proguardFile("proguard-android-optimize.txt"))
+            proguardFiles = listOf(proguardFile("proguard-rules.pro"))
         }
     }
 }

--- a/unified-prototype/unified-plugin/plugin-android-init/src/main/resources/templates/android-application-basic-activity/settings.gradle.dcl
+++ b/unified-prototype/unified-plugin/plugin-android-init/src/main/resources/templates/android-application-basic-activity/settings.gradle.dcl
@@ -6,7 +6,7 @@ pluginManagement {
 }
 
 plugins {
-    id("org.gradle.experimental.android-ecosystem").version("0.1.30")
+    id("org.gradle.experimental.android-ecosystem").version("0.1.40")
 }
 
 dependencyResolutionManagement {

--- a/unified-prototype/unified-plugin/plugin-android-init/src/main/resources/templates/android-application-empty-activity/app/build.gradle.dcl
+++ b/unified-prototype/unified-plugin/plugin-android-init/src/main/resources/templates/android-application-empty-activity/app/build.gradle.dcl
@@ -23,12 +23,8 @@ androidApplication {
                 enabled = false
             }
 
-            defaultProguardFile {
-                name = "proguard-android-optimize.txt"
-            }
-            proguardFile {
-                name = "proguard-rules.pro"
-            }
+            defaultProguardFiles = listOf(proguardFile("proguard-android-optimize.txt"))
+            proguardFiles = listOf(proguardFile("proguard-rules.pro"))
         }
 
         debug {

--- a/unified-prototype/unified-plugin/plugin-android-init/src/main/resources/templates/android-application-empty-activity/settings.gradle.dcl
+++ b/unified-prototype/unified-plugin/plugin-android-init/src/main/resources/templates/android-application-empty-activity/settings.gradle.dcl
@@ -6,7 +6,7 @@ pluginManagement {
 }
 
 plugins {
-    id("org.gradle.experimental.android-ecosystem").version("0.1.30")
+    id("org.gradle.experimental.android-ecosystem").version("0.1.40")
 }
 
 dependencyResolutionManagement {

--- a/unified-prototype/unified-plugin/plugin-android-init/src/main/resources/templates/android-application/settings.gradle.dcl
+++ b/unified-prototype/unified-plugin/plugin-android-init/src/main/resources/templates/android-application/settings.gradle.dcl
@@ -6,7 +6,7 @@ pluginManagement {
 }
 
 plugins {
-    id("org.gradle.experimental.android-ecosystem").version("0.1.30")
+    id("org.gradle.experimental.android-ecosystem").version("0.1.40")
 }
 
 rootProject.name = "example-android-app"

--- a/unified-prototype/unified-plugin/plugin-jvm/src/main/resources/templates/java-application/settings.gradle.dcl
+++ b/unified-prototype/unified-plugin/plugin-jvm/src/main/resources/templates/java-application/settings.gradle.dcl
@@ -5,7 +5,7 @@ pluginManagement {
 }
 
 plugins {
-    id("org.gradle.experimental.jvm-ecosystem").version("0.1.30")
+    id("org.gradle.experimental.jvm-ecosystem").version("0.1.40")
 }
 
 rootProject.name = "example-java-app"

--- a/unified-prototype/unified-plugin/plugin-kmp/src/main/resources/templates/kotlin-application/settings.gradle.dcl
+++ b/unified-prototype/unified-plugin/plugin-kmp/src/main/resources/templates/kotlin-application/settings.gradle.dcl
@@ -5,7 +5,7 @@ pluginManagement {
 }
 
 plugins {
-    id("org.gradle.experimental.kmp-ecosystem").version("0.1.30")
+    id("org.gradle.experimental.kmp-ecosystem").version("0.1.40")
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
This should ensure we keep the build init specs up-to-date with the latest published version.

It will make the first build after publishing a new version fail, but that should be an easy update.

**Rebase this on master after merging Gradle-plugin-plugin support**