### PR TITLE
Update prototypes to Gradle 9.6.0

### DIFF
--- a/unified-prototype/gradle/wrapper/gradle-wrapper.properties
+++ b/unified-prototype/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-milestone-7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.0-milestone-1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/unified-prototype/unified-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/unified-prototype/unified-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-milestone-7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.0-milestone-1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/unified-prototype/unified-plugin/plugin-android-init/src/main/resources/templates/android-application-basic-activity/settings.gradle.dcl
+++ b/unified-prototype/unified-plugin/plugin-android-init/src/main/resources/templates/android-application-basic-activity/settings.gradle.dcl
@@ -6,7 +6,7 @@ pluginManagement {
 }
 
 plugins {
-    id("org.gradle.experimental.android-ecosystem").version("0.1.58")
+    id("org.gradle.experimental.android-ecosystem").version("0.1.59")
 }
 
 dependencyResolutionManagement {

--- a/unified-prototype/unified-plugin/plugin-android-init/src/main/resources/templates/android-application-empty-activity/settings.gradle.dcl
+++ b/unified-prototype/unified-plugin/plugin-android-init/src/main/resources/templates/android-application-empty-activity/settings.gradle.dcl
@@ -6,7 +6,7 @@ pluginManagement {
 }
 
 plugins {
-    id("org.gradle.experimental.android-ecosystem").version("0.1.58")
+    id("org.gradle.experimental.android-ecosystem").version("0.1.59")
 }
 
 dependencyResolutionManagement {

--- a/unified-prototype/unified-plugin/plugin-android-init/src/main/resources/templates/android-application/settings.gradle.dcl
+++ b/unified-prototype/unified-plugin/plugin-android-init/src/main/resources/templates/android-application/settings.gradle.dcl
@@ -6,7 +6,7 @@ pluginManagement {
 }
 
 plugins {
-    id("org.gradle.experimental.android-ecosystem").version("0.1.58")
+    id("org.gradle.experimental.android-ecosystem").version("0.1.59")
 }
 
 rootProject.name = "example-android-app"

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/application/StandaloneAndroidApplicationPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/application/StandaloneAndroidApplicationPlugin.java
@@ -10,6 +10,8 @@ import org.gradle.api.experimental.android.extensions.linting.LintSupport;
 import org.gradle.api.experimental.android.nia.NiaSupport;
 import org.gradle.api.plugins.PluginManager;
 import org.gradle.features.annotations.BindsProjectType;
+import org.gradle.features.binding.ProjectFeatureApplicationContext;
+import org.gradle.features.binding.ProjectTypeApplyAction;
 import org.gradle.features.binding.ProjectTypeBinding;
 import org.gradle.features.binding.ProjectTypeBindingBuilder;
 
@@ -30,56 +32,62 @@ public abstract class StandaloneAndroidApplicationPlugin implements Plugin<Proje
     static class Binding implements ProjectTypeBinding {
         @Override
         public void bind(ProjectTypeBindingBuilder builder) {
-            builder.bindProjectType(ANDROID_APPLICATION, AndroidApplication.class, (context, definition, buildModel) -> {
-                Services services = context.getObjectFactory().newInstance(Services.class);
+            builder.bindProjectType(ANDROID_APPLICATION, AndroidApplication.class, ApplyAction.class)
+                .withUnsafeDefinition()
+                .withUnsafeApplyAction()
+                .withBuildModelImplementationType(DefaultAndroidApplicationBuildModel.class);
+        }
 
+        @SuppressWarnings("UnstableApiUsage")
+        static abstract class ApplyAction implements ProjectTypeApplyAction<AndroidApplication, AndroidApplicationBuildModel> {
+            @Inject
+            public ApplyAction() {
+            }
+
+            @Inject
+            protected abstract PluginManager getPluginManager();
+
+            @Inject
+            protected abstract Project getProject();
+
+            @Override
+            public void apply(ProjectFeatureApplicationContext context, AndroidApplication definition, AndroidApplicationBuildModel buildModel) {
                 // Apply the official Android plugin.
-                services.getPluginManager().apply("com.android.application");
+                getPluginManager().apply("com.android.application");
 
                 // Add the legacy extension to the build model
-                ((DefaultAndroidApplicationBuildModel)buildModel).setApplicationExtension(
-                        services.getProject().getExtensions().getByType(ApplicationExtension.class)
+                ((DefaultAndroidApplicationBuildModel) buildModel).setApplicationExtension(
+                        getProject().getExtensions().getByType(ApplicationExtension.class)
                 );
 
                 // Configure android extension from the definition
-                linkDefinitionToPlugin(services.getProject(), definition, buildModel, services.getProject().getConfigurations());
-            })
-            .withUnsafeDefinition()
-            .withUnsafeApplyAction()
-            .withBuildModelImplementationType(DefaultAndroidApplicationBuildModel.class);
-        }
-
-        /**
-         * Performs linking actions that must occur within an afterEvaluate block.
-         */
-        private void linkDefinitionToPlugin(Project project, AndroidApplication definition, AndroidApplicationBuildModel buildModel, ConfigurationContainer configurations) {
-            ApplicationExtension android = buildModel.getApplicationExtension();
-            AndroidBindingSupport.linkCommonDependencies(definition.getDependencies(), configurations);
-            AndroidBindingSupport.linkDefinitionToPlugin(project, definition, android);
-
-            android.defaultConfig(defaultConfig -> {
-                ifPresent(definition.getVersionCode(), defaultConfig::setVersionCode);
-                ifPresent(definition.getVersionName(), defaultConfig::setVersionName);
-                ifPresent(definition.getApplicationId(), defaultConfig::setApplicationId);
-                return null;
-            });
-            LintSupport.configureLint(project, definition);
-
-            android.getBuildFeatures().setViewBinding(definition.getViewBinding().getEnabled().get());
-            android.getBuildFeatures().setDataBinding(definition.getDataBinding().getEnabled().get());
-
-            // TODO:DG All this configuration should be moved to the NiA project
-            if (NiaSupport.isNiaProject(project)) {
-                NiaSupport.configureNiaApplication(project, definition);
+                linkDefinitionToPlugin(getProject(), definition, buildModel, getProject().getConfigurations());
             }
-        }
 
-        interface Services {
-            @Inject
-            PluginManager getPluginManager();
+            /**
+             * Performs linking actions that must occur within an afterEvaluate block.
+             */
+            private void linkDefinitionToPlugin(Project project, AndroidApplication definition, AndroidApplicationBuildModel buildModel, ConfigurationContainer configurations) {
+                ApplicationExtension android = buildModel.getApplicationExtension();
+                AndroidBindingSupport.linkCommonDependencies(definition.getDependencies(), configurations);
+                AndroidBindingSupport.linkDefinitionToPlugin(project, definition, android);
 
-            @Inject
-            Project getProject();
+                android.defaultConfig(defaultConfig -> {
+                    ifPresent(definition.getVersionCode(), defaultConfig::setVersionCode);
+                    ifPresent(definition.getVersionName(), defaultConfig::setVersionName);
+                    ifPresent(definition.getApplicationId(), defaultConfig::setApplicationId);
+                    return null;
+                });
+                LintSupport.configureLint(project, definition);
+
+                android.getBuildFeatures().setViewBinding(definition.getViewBinding().getEnabled().get());
+                android.getBuildFeatures().setDataBinding(definition.getDataBinding().getEnabled().get());
+
+                // TODO:DG All this configuration should be moved to the NiA project
+                if (NiaSupport.isNiaProject(project)) {
+                    NiaSupport.configureNiaApplication(project, definition);
+                }
+            }
         }
     }
 

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/library/StandaloneAndroidLibraryPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/library/StandaloneAndroidLibraryPlugin.java
@@ -13,6 +13,8 @@ import org.gradle.api.experimental.android.library.internal.DefaultAndroidLibrar
 import org.gradle.api.experimental.android.nia.NiaSupport;
 import org.gradle.api.plugins.PluginManager;
 import org.gradle.features.annotations.BindsProjectType;
+import org.gradle.features.binding.ProjectFeatureApplicationContext;
+import org.gradle.features.binding.ProjectTypeApplyAction;
 import org.gradle.features.binding.ProjectTypeBinding;
 import org.gradle.features.binding.ProjectTypeBindingBuilder;
 import org.jetbrains.kotlin.com.google.common.base.Preconditions;
@@ -36,88 +38,93 @@ public abstract class StandaloneAndroidLibraryPlugin implements Plugin<Project> 
     static class Binding implements ProjectTypeBinding {
         @Override
         public void bind(ProjectTypeBindingBuilder builder) {
-            builder.bindProjectType(ANDROID_LIBRARY, AndroidLibrary.class, (context, definition, buildModel) -> {
-                Services services = context.getObjectFactory().newInstance(Services.class);
-
-                // Apply the official Android plugin and support for Kotlin
-                services.getPluginManager().apply("com.android.library");
-
-                // Add the legacy extension to the build model
-                ((DefaultAndroidLibraryBuildModel) buildModel).setLibraryExtension(
-                        services.getProject().getExtensions().getByType(LibraryExtension.class)
-                );
-
-                // Configure android extension from the definition
-                linkDefinitionToPlugin(services.getProject(), definition, buildModel, services.getProject().getConfigurations());
-            })
-            .withUnsafeDefinition()
-            .withUnsafeApplyAction()
-            .withBuildModelImplementationType(DefaultAndroidLibraryBuildModel.class);
-        }
-
-        /**
-         * Performs linking actions that must occur within an afterEvaluate block.
-         */
-        private void linkDefinitionToPlugin(Project project, AndroidLibrary dslModel, AndroidLibraryBuildModel buildModel, ConfigurationContainer configurations) {
-            LibraryExtension android = buildModel.getLibraryExtension();
-            linkCommonDependencies(dslModel.getDependencies(), configurations);
-            AndroidBindingSupport.linkDefinitionToPlugin(project, dslModel, android);
-
-            configureProtobuf(project, dslModel, android);
-
-            // TODO:DG All this configuration should be moved to the NiA project
-            if (NiaSupport.isNiaProject(project)) {
-                NiaSupport.configureNiaLibrary(project, dslModel);
-            }
-            LintSupport.configureLint(project, dslModel);
-            ifPresent(dslModel.getConsumerProguardFiles(), android.getDefaultConfig()::consumerProguardFile);
-            ifPresent(dslModel.getBuildConfig(), android.getBuildFeatures()::setBuildConfig);
-        }
-
-        protected void configureProtobuf(Project project, AndroidLibrary dslModel, CommonExtension android) {
-            if (dslModel.getProtobuf().getEnabled().get()) {
-                project.getPlugins().apply("com.google.protobuf");
-
-                String option = dslModel.getProtobuf().getOption().getOrNull();
-                project.getLogger().info("Protobuf is enabled using option=" + option + " in: " + project.getPath());
-                if (Objects.equals(option, "lite")) {
-                    dslModel.getDependencies().getApi().add("com.google.protobuf:protobuf-kotlin-lite:" + dslModel.getProtobuf().getVersion().get());
-
-                    ProtobufExtension protobuf = project.getExtensions().getByType(ProtobufExtension.class);
-                    String protocGAV = getProtocDepGAV(dslModel);
-                    protobuf.protoc(protoc -> protoc.setArtifact(protocGAV));
-
-                    protobuf.generateProtoTasks(generator -> {
-                        generator.all().forEach(task -> {
-                            task.getBuiltins().create("java", builtin -> builtin.getOptions().add("lite"));
-                            task.getBuiltins().create("kotlin", builtin -> builtin.getOptions().add("lite"));
-                        });
-                    });
-                } else {
-                    throw new IllegalStateException("We only support lite option currently, not: " + option);
-                }
-            }
-        }
-
-        private static String getProtocDepGAV(AndroidLibrary dslModel) {
-            Set<Dependency> protocDeps = dslModel.getProtobuf().getDependencies().getProtoc().getDependencies().get();
-            Preconditions.checkState(protocDeps.size() == 1, "Should have a single dependency, but had: " + protocDeps.size());
-            Dependency protocDep = protocDeps.iterator().next();
-            return protocDep.getGroup() + ":" + protocDep.getName() + ":" + protocDep.getVersion();
+            builder.bindProjectType(ANDROID_LIBRARY, AndroidLibrary.class, ApplyAction.class)
+                .withUnsafeDefinition()
+                .withUnsafeApplyAction()
+                .withBuildModelImplementationType(DefaultAndroidLibraryBuildModel.class);
         }
 
         @SuppressWarnings("UnstableApiUsage")
-        private void linkCommonDependencies(AndroidLibraryDependencies dependencies, ConfigurationContainer configurations) {
-            AndroidBindingSupport.linkCommonDependencies(dependencies, configurations);
-            configurations.getByName("api").fromDependencyCollector(dependencies.getApi()); // API deps added for libraries
-        }
-
-        interface Services {
+        static abstract class ApplyAction implements ProjectTypeApplyAction<AndroidLibrary, AndroidLibraryBuildModel> {
             @Inject
-            PluginManager getPluginManager();
+            public ApplyAction() {
+            }
 
             @Inject
-            Project getProject();
+            protected abstract PluginManager getPluginManager();
+
+            @Inject
+            protected abstract Project getProject();
+
+            @Override
+            public void apply(ProjectFeatureApplicationContext context, AndroidLibrary definition, AndroidLibraryBuildModel buildModel) {
+                // Apply the official Android plugin and support for Kotlin
+                getPluginManager().apply("com.android.library");
+
+                // Add the legacy extension to the build model
+                ((DefaultAndroidLibraryBuildModel) buildModel).setLibraryExtension(
+                        getProject().getExtensions().getByType(LibraryExtension.class)
+                );
+
+                // Configure android extension from the definition
+                linkDefinitionToPlugin(getProject(), definition, buildModel, getProject().getConfigurations());
+            }
+
+            /**
+             * Performs linking actions that must occur within an afterEvaluate block.
+             */
+            private void linkDefinitionToPlugin(Project project, AndroidLibrary dslModel, AndroidLibraryBuildModel buildModel, ConfigurationContainer configurations) {
+                LibraryExtension android = buildModel.getLibraryExtension();
+                linkCommonDependencies(dslModel.getDependencies(), configurations);
+                AndroidBindingSupport.linkDefinitionToPlugin(project, dslModel, android);
+
+                configureProtobuf(project, dslModel, android);
+
+                // TODO:DG All this configuration should be moved to the NiA project
+                if (NiaSupport.isNiaProject(project)) {
+                    NiaSupport.configureNiaLibrary(project, dslModel);
+                }
+                LintSupport.configureLint(project, dslModel);
+                ifPresent(dslModel.getConsumerProguardFiles(), android.getDefaultConfig()::consumerProguardFile);
+                ifPresent(dslModel.getBuildConfig(), android.getBuildFeatures()::setBuildConfig);
+            }
+
+            private void configureProtobuf(Project project, AndroidLibrary dslModel, CommonExtension android) {
+                if (dslModel.getProtobuf().getEnabled().get()) {
+                    project.getPlugins().apply("com.google.protobuf");
+
+                    String option = dslModel.getProtobuf().getOption().getOrNull();
+                    project.getLogger().info("Protobuf is enabled using option=" + option + " in: " + project.getPath());
+                    if (Objects.equals(option, "lite")) {
+                        dslModel.getDependencies().getApi().add("com.google.protobuf:protobuf-kotlin-lite:" + dslModel.getProtobuf().getVersion().get());
+
+                        ProtobufExtension protobuf = project.getExtensions().getByType(ProtobufExtension.class);
+                        String protocGAV = getProtocDepGAV(dslModel);
+                        protobuf.protoc(protoc -> protoc.setArtifact(protocGAV));
+
+                        protobuf.generateProtoTasks(generator -> {
+                            generator.all().forEach(task -> {
+                                task.getBuiltins().create("java", builtin -> builtin.getOptions().add("lite"));
+                                task.getBuiltins().create("kotlin", builtin -> builtin.getOptions().add("lite"));
+                            });
+                        });
+                    } else {
+                        throw new IllegalStateException("We only support lite option currently, not: " + option);
+                    }
+                }
+            }
+
+            private static String getProtocDepGAV(AndroidLibrary dslModel) {
+                Set<Dependency> protocDeps = dslModel.getProtobuf().getDependencies().getProtoc().getDependencies().get();
+                Preconditions.checkState(protocDeps.size() == 1, "Should have a single dependency, but had: " + protocDeps.size());
+                Dependency protocDep = protocDeps.iterator().next();
+                return protocDep.getGroup() + ":" + protocDep.getName() + ":" + protocDep.getVersion();
+            }
+
+            private void linkCommonDependencies(AndroidLibraryDependencies dependencies, ConfigurationContainer configurations) {
+                AndroidBindingSupport.linkCommonDependencies(dependencies, configurations);
+                configurations.getByName("api").fromDependencyCollector(dependencies.getApi()); // API deps added for libraries
+            }
         }
     }
 

--- a/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/test/StandaloneAndroidTestPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/test/StandaloneAndroidTestPlugin.java
@@ -13,6 +13,8 @@ import org.gradle.api.experimental.android.nia.NiaSupport;
 import org.gradle.api.experimental.android.test.internal.DefaultAndroidTestBuildModel;
 import org.gradle.api.plugins.PluginManager;
 import org.gradle.features.annotations.BindsProjectType;
+import org.gradle.features.binding.ProjectFeatureApplicationContext;
+import org.gradle.features.binding.ProjectTypeApplyAction;
 import org.gradle.features.binding.ProjectTypeBinding;
 import org.gradle.features.binding.ProjectTypeBindingBuilder;
 
@@ -31,84 +33,90 @@ public abstract class StandaloneAndroidTestPlugin implements Plugin<Project> {
     static class Binding implements ProjectTypeBinding {
         @Override
         public void bind(ProjectTypeBindingBuilder builder) {
-            builder.bindProjectType(ANDROID_TEST, AndroidTest.class, (context, definition, buildModel) -> {
-                Services services = context.getObjectFactory().newInstance(Services.class);
-
-                // Register an afterEvaluate listener before we apply the Android plugin to ensure we can
-                // run actions before Android does.
-                services.getProject().afterEvaluate(p -> linkDefinitionToPlugin(p, definition, buildModel));
-
-                // Apply the official Android plugin and support for Kotlin
-                services.getPluginManager().apply("com.android.test");
-                services.getPluginManager().apply("org.jetbrains.kotlin.android");
-
-                ((DefaultAndroidTestBuildModel)buildModel).setTestExtension(services.getProject().getExtensions().getByType(TestExtension.class));
-            })
+            builder.bindProjectType(ANDROID_TEST, AndroidTest.class, ApplyAction.class)
             .withUnsafeDefinition()
             .withUnsafeApplyAction()
             .withBuildModelImplementationType(DefaultAndroidTestBuildModel.class);
         }
 
-        /**
-         * Performs linking actions that must occur within an afterEvaluate block.
-         */
-        private void linkDefinitionToPlugin(Project project, AndroidTest definition, AndroidTestBuildModel buildModel) {
-            TestExtension android = buildModel.getTestExtension();
-
-            ifPresent(definition.getNamespace(), android::setNamespace);
-            ifPresent(definition.getCompileSdk(), android::setCompileSdk);
-            android.defaultConfig(defaultConfig -> {
-                ifPresent(definition.getMinSdk(), defaultConfig::setMinSdk);
-                return null;
-            });
-
-            definition.getExperimentalProperties().forEach(property -> {
-                android.getExperimentalProperties().put(property.getName(), property.getValue().get());
-            });
-
-            ifPresent(definition.getTargetProjectPath(), android::setTargetProjectPath);
-
-            android.compileOptions(compileOptions -> {
-                // Up to Java 11 APIs are available through desugaring
-                // https://developer.android.com/studio/write/java11-minimal-support-table
-                compileOptions.setSourceCompatibility(JavaVersion.toVersion(definition.getJdkVersion().get()));
-                compileOptions.setTargetCompatibility(JavaVersion.toVersion(definition.getJdkVersion().get()));
-                return null;
-            });
-
-            TestOptions testOptions = definition.getTestOptions();
-            ifPresent(testOptions.getTestInstrumentationRunner(), android.getDefaultConfig()::setTestInstrumentationRunner);
-            testOptions.getManagedDevices().forEach(device -> {
-                ManagedVirtualDevice managedVirtualDevice = android.getTestOptions().getManagedDevices().getAllDevices().create(device.getName(), ManagedVirtualDevice.class);
-                ifPresent(device.getDevice(), managedVirtualDevice::setDevice);
-                ifPresent(device.getApiLevel(), managedVirtualDevice::setApiLevel);
-                ifPresent(device.getSystemImageSource(), managedVirtualDevice::setSystemImageSource);
-            });
-
-            UnitTestOptions unitTestOptions = android.getTestOptions().getUnitTests();
-            unitTestOptions.setIncludeAndroidResources(testOptions.getIncludeAndroidResources().get());
-            unitTestOptions.setReturnDefaultValues(testOptions.getReturnDefaultValues().get());
-
-            AndroidTestDependencies testDependencies = definition.getDependencies();
-            ConfigurationContainer configurations = project.getConfigurations();
-            configurations.getByName("implementation").fromDependencyCollector(testDependencies.getImplementation());
-            configurations.getByName("compileOnly").fromDependencyCollector(testDependencies.getCompileOnly());
-            configurations.getByName("runtimeOnly").fromDependencyCollector(testDependencies.getRuntimeOnly());
-            // AndroidTestImplementation not usable here?
-
-            // TODO:DG All this configuration should be moved to the NiA project
-            if (NiaSupport.isNiaProject(project)) {
-                NiaSupport.configureNiaTest(project, definition);
+        @SuppressWarnings("UnstableApiUsage")
+        static abstract class ApplyAction implements ProjectTypeApplyAction<AndroidTest, AndroidTestBuildModel> {
+            @Inject
+            public ApplyAction() {
             }
-            ifPresent(definition.getBuildConfig(), android.getBuildFeatures()::setBuildConfig);
-        }
-
-        interface Services {
-            @Inject
-            PluginManager getPluginManager();
 
             @Inject
-            Project getProject();
+            protected abstract PluginManager getPluginManager();
+
+            @Inject
+            protected abstract Project getProject();
+
+            @Override
+            public void apply(ProjectFeatureApplicationContext context, AndroidTest definition, AndroidTestBuildModel buildModel) {
+                // Register an afterEvaluate listener before we apply the Android plugin to ensure we can
+                // run actions before Android does.
+                getProject().afterEvaluate(p -> linkDefinitionToPlugin(p, definition, buildModel));
+
+                // Apply the official Android plugin and support for Kotlin
+                getPluginManager().apply("com.android.test");
+                getPluginManager().apply("org.jetbrains.kotlin.android");
+
+                ((DefaultAndroidTestBuildModel) buildModel).setTestExtension(getProject().getExtensions().getByType(TestExtension.class));
+            }
+
+            /**
+             * Performs linking actions that must occur within an afterEvaluate block.
+             */
+            private void linkDefinitionToPlugin(Project project, AndroidTest definition, AndroidTestBuildModel buildModel) {
+                TestExtension android = buildModel.getTestExtension();
+
+                ifPresent(definition.getNamespace(), android::setNamespace);
+                ifPresent(definition.getCompileSdk(), android::setCompileSdk);
+                android.defaultConfig(defaultConfig -> {
+                    ifPresent(definition.getMinSdk(), defaultConfig::setMinSdk);
+                    return null;
+                });
+
+                definition.getExperimentalProperties().forEach(property -> {
+                    android.getExperimentalProperties().put(property.getName(), property.getValue().get());
+                });
+
+                ifPresent(definition.getTargetProjectPath(), android::setTargetProjectPath);
+
+                android.compileOptions(compileOptions -> {
+                    // Up to Java 11 APIs are available through desugaring
+                    // https://developer.android.com/studio/write/java11-minimal-support-table
+                    compileOptions.setSourceCompatibility(JavaVersion.toVersion(definition.getJdkVersion().get()));
+                    compileOptions.setTargetCompatibility(JavaVersion.toVersion(definition.getJdkVersion().get()));
+                    return null;
+                });
+
+                TestOptions testOptions = definition.getTestOptions();
+                ifPresent(testOptions.getTestInstrumentationRunner(), android.getDefaultConfig()::setTestInstrumentationRunner);
+                testOptions.getManagedDevices().forEach(device -> {
+                    ManagedVirtualDevice managedVirtualDevice = android.getTestOptions().getManagedDevices().getAllDevices().create(device.getName(), ManagedVirtualDevice.class);
+                    ifPresent(device.getDevice(), managedVirtualDevice::setDevice);
+                    ifPresent(device.getApiLevel(), managedVirtualDevice::setApiLevel);
+                    ifPresent(device.getSystemImageSource(), managedVirtualDevice::setSystemImageSource);
+                });
+
+                UnitTestOptions unitTestOptions = android.getTestOptions().getUnitTests();
+                unitTestOptions.setIncludeAndroidResources(testOptions.getIncludeAndroidResources().get());
+                unitTestOptions.setReturnDefaultValues(testOptions.getReturnDefaultValues().get());
+
+                AndroidTestDependencies testDependencies = definition.getDependencies();
+                ConfigurationContainer configurations = project.getConfigurations();
+                configurations.getByName("implementation").fromDependencyCollector(testDependencies.getImplementation());
+                configurations.getByName("compileOnly").fromDependencyCollector(testDependencies.getCompileOnly());
+                configurations.getByName("runtimeOnly").fromDependencyCollector(testDependencies.getRuntimeOnly());
+                // AndroidTestImplementation not usable here?
+
+                // TODO:DG All this configuration should be moved to the NiA project
+                if (NiaSupport.isNiaProject(project)) {
+                    NiaSupport.configureNiaTest(project, definition);
+                }
+                ifPresent(definition.getBuildConfig(), android.getBuildFeatures()::setBuildConfig);
+            }
         }
     }
 

--- a/unified-prototype/unified-plugin/plugin-cpp/src/main/java/org/gradle/api/experimental/cpp/StandaloneCppApplicationPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-cpp/src/main/java/org/gradle/api/experimental/cpp/StandaloneCppApplicationPlugin.java
@@ -10,6 +10,8 @@ import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Exec;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.features.annotations.BindsProjectType;
+import org.gradle.features.binding.ProjectFeatureApplicationContext;
+import org.gradle.features.binding.ProjectTypeApplyAction;
 import org.gradle.features.binding.ProjectTypeBinding;
 import org.gradle.features.binding.ProjectTypeBindingBuilder;
 import org.gradle.features.registration.TaskRegistrar;
@@ -28,50 +30,57 @@ public abstract class StandaloneCppApplicationPlugin implements Plugin<Project> 
     static class Binding implements ProjectTypeBinding {
         @Override
         public void bind(ProjectTypeBindingBuilder builder) {
-            builder.bindProjectType(CPP_APPLICATION, CppApplication.class, (context, definition, buildModel) ->{
-                Services services = context.getObjectFactory().newInstance(Services.class);
-                services.getPluginManager().apply(CppApplicationPlugin.class);
-
-                CliExecutablesSupport.configureRunTasks(services.getTaskRegistrar(), buildModel);
-
-                ((DefaultCppApplicationBuildModel) buildModel).setCppComponent(services.getProject().getExtensions().getByType(CppComponent.class));
-
-                linkDefinitionToPlugin(services.getProject(), definition, buildModel);
-            })
-            .withUnsafeDefinition()
-            .withUnsafeApplyAction()
-            .withBuildModelImplementationType(DefaultCppApplicationBuildModel.class);
+            builder.bindProjectType(CPP_APPLICATION, CppApplication.class, ApplyAction.class)
+                .withUnsafeDefinition()
+                .withUnsafeApplyAction()
+                .withBuildModelImplementationType(DefaultCppApplicationBuildModel.class);
         }
 
-        private void linkDefinitionToPlugin(Project project, CppApplication definition, CppApplicationBuildModel buildModel) {
-            CppComponent model = buildModel.getCppComponent();
-
-            model.getImplementationDependencies().getDependencies().addAllLater(definition.getDependencies().getImplementation().getDependencies());
-
-            project.getComponents().withType(org.gradle.language.cpp.CppApplication.class).configureEach(applicationComponent ->
-                applicationComponent.getBinaries().configureEach(binary -> {
-                    binary.getCompileTask().get().getCompilerArgs().add(definition.getCppVersion().map(v -> "--std=" + v));
-                    if (binary instanceof CppExecutable) {
-                        Provider<RegularFile> executable = ((CppExecutable) binary).getDebuggerExecutableFile();
-                        TaskProvider<Exec> runTask = project.getTasks().register("run" + TextUtil.capitalize(binary.getName()), Exec.class, task -> {
-                            task.executable(executable.get().getAsFile().getAbsoluteFile());
-                            task.dependsOn(executable);
-                        });
-                        buildModel.getRunTasks().add(runTask);
-                    }
-                })
-            );
-        }
-
-        interface Services {
+        @SuppressWarnings("UnstableApiUsage")
+        static abstract class ApplyAction implements ProjectTypeApplyAction<CppApplication, CppApplicationBuildModel> {
             @Inject
-            PluginManager getPluginManager();
+            public ApplyAction() {
+            }
 
             @Inject
-            TaskRegistrar getTaskRegistrar();
+            protected abstract PluginManager getPluginManager();
 
             @Inject
-            Project getProject();
+            protected abstract TaskRegistrar getTaskRegistrar();
+
+            @Inject
+            protected abstract Project getProject();
+
+            @Override
+            public void apply(ProjectFeatureApplicationContext context, CppApplication definition, CppApplicationBuildModel buildModel) {
+                getPluginManager().apply(CppApplicationPlugin.class);
+
+                CliExecutablesSupport.configureRunTasks(getTaskRegistrar(), buildModel);
+
+                ((DefaultCppApplicationBuildModel) buildModel).setCppComponent(getProject().getExtensions().getByType(CppComponent.class));
+
+                linkDefinitionToPlugin(getProject(), definition, buildModel);
+            }
+
+            private void linkDefinitionToPlugin(Project project, CppApplication definition, CppApplicationBuildModel buildModel) {
+                CppComponent model = buildModel.getCppComponent();
+
+                model.getImplementationDependencies().getDependencies().addAllLater(definition.getDependencies().getImplementation().getDependencies());
+
+                project.getComponents().withType(org.gradle.language.cpp.CppApplication.class).configureEach(applicationComponent ->
+                    applicationComponent.getBinaries().configureEach(binary -> {
+                        binary.getCompileTask().get().getCompilerArgs().add(definition.getCppVersion().map(v -> "--std=" + v));
+                        if (binary instanceof CppExecutable) {
+                            Provider<RegularFile> executable = ((CppExecutable) binary).getDebuggerExecutableFile();
+                            TaskProvider<Exec> runTask = project.getTasks().register("run" + TextUtil.capitalize(binary.getName()), Exec.class, task -> {
+                                task.executable(executable.get().getAsFile().getAbsoluteFile());
+                                task.dependsOn(executable);
+                            });
+                            buildModel.getRunTasks().add(runTask);
+                        }
+                    })
+                );
+            }
         }
     }
 

--- a/unified-prototype/unified-plugin/plugin-cpp/src/main/java/org/gradle/api/experimental/cpp/StandaloneCppLibraryPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-cpp/src/main/java/org/gradle/api/experimental/cpp/StandaloneCppLibraryPlugin.java
@@ -5,6 +5,8 @@ import org.gradle.api.Project;
 import org.gradle.api.experimental.cpp.internal.DefaultCppLibraryBuildModel;
 import org.gradle.api.plugins.PluginManager;
 import org.gradle.features.annotations.BindsProjectType;
+import org.gradle.features.binding.ProjectFeatureApplicationContext;
+import org.gradle.features.binding.ProjectTypeApplyAction;
 import org.gradle.features.binding.ProjectTypeBinding;
 import org.gradle.features.binding.ProjectTypeBindingBuilder;
 import org.gradle.language.cpp.plugins.CppLibraryPlugin;
@@ -19,38 +21,45 @@ public abstract class StandaloneCppLibraryPlugin implements Plugin<Project> {
     static class Binding implements ProjectTypeBinding {
         @Override
         public void bind(ProjectTypeBindingBuilder builder) {
-            builder.bindProjectType(CPP_LIBRARY, CppLibrary.class, (context, definition, buildModel) -> {
-                Services services = context.getObjectFactory().newInstance(Services.class);
-                services.getPluginManager().apply(CppLibraryPlugin.class);
-
-                ((DefaultCppLibraryBuildModel) buildModel).setCppLibrary(services.getProject().getExtensions().getByType(org.gradle.language.cpp.CppLibrary.class));
-
-                linkDefinitionToPlugin(services.getProject(), definition, buildModel);
-            })
-            .withUnsafeDefinition()
-            .withUnsafeApplyAction()
-            .withBuildModelImplementationType(DefaultCppLibraryBuildModel.class);
+            builder.bindProjectType(CPP_LIBRARY, CppLibrary.class, ApplyAction.class)
+                .withUnsafeDefinition()
+                .withUnsafeApplyAction()
+                .withBuildModelImplementationType(DefaultCppLibraryBuildModel.class);
         }
 
-        private void linkDefinitionToPlugin(Project project, CppLibrary library, CppLibraryBuildModel buildModel) {
-            org.gradle.language.cpp.CppLibrary model = buildModel.getCppLibrary();
-
-            model.getImplementationDependencies().getDependencies().addAllLater(library.getDependencies().getImplementation().getDependencies());
-            model.getApiDependencies().getDependencies().addAllLater(library.getDependencies().getApi().getDependencies());
-
-            project.getComponents().withType(org.gradle.language.cpp.CppLibrary.class).configureEach(libraryComponent ->
-                libraryComponent.getBinaries().configureEach(binary -> {
-                    binary.getCompileTask().get().getCompilerArgs().add(library.getCppVersion().map(v -> "--std=" + v));
-                })
-            );
-        }
-
-        interface Services {
+        @SuppressWarnings("UnstableApiUsage")
+        static abstract class ApplyAction implements ProjectTypeApplyAction<CppLibrary, CppLibraryBuildModel> {
             @Inject
-            PluginManager getPluginManager();
+            public ApplyAction() {
+            }
 
             @Inject
-            Project getProject();
+            protected abstract PluginManager getPluginManager();
+
+            @Inject
+            protected abstract Project getProject();
+
+            @Override
+            public void apply(ProjectFeatureApplicationContext context, CppLibrary definition, CppLibraryBuildModel buildModel) {
+                getPluginManager().apply(CppLibraryPlugin.class);
+
+                ((DefaultCppLibraryBuildModel) buildModel).setCppLibrary(getProject().getExtensions().getByType(org.gradle.language.cpp.CppLibrary.class));
+
+                linkDefinitionToPlugin(getProject(), definition, buildModel);
+            }
+
+            private void linkDefinitionToPlugin(Project project, CppLibrary library, CppLibraryBuildModel buildModel) {
+                org.gradle.language.cpp.CppLibrary model = buildModel.getCppLibrary();
+
+                model.getImplementationDependencies().getDependencies().addAllLater(library.getDependencies().getImplementation().getDependencies());
+                model.getApiDependencies().getDependencies().addAllLater(library.getDependencies().getApi().getDependencies());
+
+                project.getComponents().withType(org.gradle.language.cpp.CppLibrary.class).configureEach(libraryComponent ->
+                    libraryComponent.getBinaries().configureEach(binary -> {
+                        binary.getCompileTask().get().getCompilerArgs().add(library.getCppVersion().map(v -> "--std=" + v));
+                    })
+                );
+            }
         }
     }
 

--- a/unified-prototype/unified-plugin/plugin-jvm/src/integTest/groovy/org/gradle/api/experimental/jvm/JavaLibraryWithCheckstyleIntegrationTest.groovy
+++ b/unified-prototype/unified-plugin/plugin-jvm/src/integTest/groovy/org/gradle/api/experimental/jvm/JavaLibraryWithCheckstyleIntegrationTest.groovy
@@ -62,7 +62,7 @@ class JavaLibraryWithCheckstyleIntegrationTest extends AbstractSpecification {
         def result = fails(":checkstyleMain")
 
         then:
-        result.output.contains("Execution failed for task ':checkstyleMain'.")
+        result.output.contains("Execution failed for task ':checkstyleMain'")
         result.output.contains("Checkstyle rule violations were found. See the report at:")
         result.output.contains("Name 'example' must match pattern")
     }

--- a/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/java/StandaloneJavaApplicationPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/java/StandaloneJavaApplicationPlugin.java
@@ -14,6 +14,8 @@ import org.gradle.api.plugins.PluginManager;
 import org.gradle.api.plugins.jvm.JvmTestSuite;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.features.annotations.BindsProjectType;
+import org.gradle.features.binding.ProjectFeatureApplicationContext;
+import org.gradle.features.binding.ProjectTypeApplyAction;
 import org.gradle.features.binding.ProjectTypeBinding;
 import org.gradle.features.binding.ProjectTypeBindingBuilder;
 import org.gradle.features.registration.TaskRegistrar;
@@ -42,59 +44,53 @@ public abstract class StandaloneJavaApplicationPlugin implements Plugin<Project>
     static class Binding implements ProjectTypeBinding {
         @Override
         public void bind(ProjectTypeBindingBuilder builder) {
-            builder.bindProjectType(JAVA_APPLICATION, JavaApplication.class,
-                    (context, definition, buildModel) -> {
-                        Services services = context.getObjectFactory().newInstance(Services.class);
-                        services.getPluginManager().apply(ApplicationPlugin.class);
-                        CliExecutablesSupport.configureRunTasks(services.getTaskRegistrar(), buildModel);
-                        ((DefaultJavaBuildModel) buildModel).setJavaPluginExtension(
-                                services.getProject().getExtensions().getByType(JavaPluginExtension.class)
-                        );
-                        ((DefaultJavaApplicationBuildModel) buildModel).setJavaApplicationExtension(
-                                services.getProject().getExtensions().getByType(org.gradle.api.plugins.JavaApplication.class)
-                        );
-
-                        context.getObjectFactory().newInstance(ModelToPluginLinker.class).link(
-                                definition,
-                                buildModel,
-                                services.getProject().getConfigurations(),
-                                services.getProject().getTasks()
-                        );
-                    }
-            )
+            builder.bindProjectType(JAVA_APPLICATION, JavaApplication.class, ApplyAction.class)
             .withUnsafeDefinition()
             .withUnsafeApplyAction()
             .withBuildModelImplementationType(DefaultJavaApplicationBuildModel.class);
         }
 
-        interface Services {
+        @SuppressWarnings("UnstableApiUsage")
+        static abstract class ApplyAction implements ProjectTypeApplyAction<JavaApplication, JavaApplicationBuildModel> {
             @Inject
-            PluginManager getPluginManager();
+            public ApplyAction() {
+            }
 
             @Inject
-            TaskRegistrar getTaskRegistrar();
+            protected abstract PluginManager getPluginManager();
 
             @Inject
-            Project getProject();
-        }
-    }
+            protected abstract TaskRegistrar getTaskRegistrar();
 
-    static abstract class ModelToPluginLinker {
-        @Inject
-        public ModelToPluginLinker() {
-        }
+            @Inject
+            protected abstract Project getProject();
 
-        @Inject
-        protected abstract JavaToolchainService getJavaToolchainService();
+            @Inject
+            protected abstract JavaToolchainService getJavaToolchainService();
 
-        private void link(JavaApplication definition, JavaApplicationBuildModel buildModel, ConfigurationContainer configurations, TaskContainer tasks) {
-            JvmPluginSupport.linkJavaVersion(definition, buildModel.getJavaPluginExtension());
-            JvmPluginSupport.linkApplicationMainClass(definition, buildModel.getJavaApplicationExtension());
-            JvmPluginSupport.linkMainSourceSourceSetDependencies(definition.getDependencies(), buildModel.getJavaPluginExtension(), configurations);
-            JvmPluginSupport.linkTestJavaVersion(definition.getTesting(), getJavaToolchainService(), tasks);
-            JvmPluginSupport.linkTestSourceSourceSetDependencies(definition.getTesting().getDependencies(), buildModel.getJavaPluginExtension(), configurations);
+            @Override
+            public void apply(ProjectFeatureApplicationContext context, JavaApplication definition, JavaApplicationBuildModel buildModel) {
+                getPluginManager().apply(ApplicationPlugin.class);
+                CliExecutablesSupport.configureRunTasks(getTaskRegistrar(), buildModel);
+                ((DefaultJavaBuildModel) buildModel).setJavaPluginExtension(
+                        getProject().getExtensions().getByType(JavaPluginExtension.class)
+                );
+                ((DefaultJavaApplicationBuildModel) buildModel).setJavaApplicationExtension(
+                        getProject().getExtensions().getByType(org.gradle.api.plugins.JavaApplication.class)
+                );
 
-            buildModel.getRunTasks().add(tasks.named("run"));
+                link(definition, buildModel, getProject().getConfigurations(), getProject().getTasks());
+            }
+
+            private void link(JavaApplication definition, JavaApplicationBuildModel buildModel, ConfigurationContainer configurations, TaskContainer tasks) {
+                JvmPluginSupport.linkJavaVersion(definition, buildModel.getJavaPluginExtension());
+                JvmPluginSupport.linkApplicationMainClass(definition, buildModel.getJavaApplicationExtension());
+                JvmPluginSupport.linkMainSourceSourceSetDependencies(definition.getDependencies(), buildModel.getJavaPluginExtension(), configurations);
+                JvmPluginSupport.linkTestJavaVersion(definition.getTesting(), getJavaToolchainService(), tasks);
+                JvmPluginSupport.linkTestSourceSourceSetDependencies(definition.getTesting().getDependencies(), buildModel.getJavaPluginExtension(), configurations);
+
+                buildModel.getRunTasks().add(tasks.named("run"));
+            }
         }
     }
 }

--- a/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/java/StandaloneJavaLibraryPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/java/StandaloneJavaLibraryPlugin.java
@@ -12,6 +12,8 @@ import org.gradle.api.plugins.PluginManager;
 import org.gradle.api.plugins.jvm.JvmTestSuite;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.features.annotations.BindsProjectType;
+import org.gradle.features.binding.ProjectFeatureApplicationContext;
+import org.gradle.features.binding.ProjectTypeApplyAction;
 import org.gradle.features.binding.ProjectTypeBinding;
 import org.gradle.features.binding.ProjectTypeBindingBuilder;
 import org.gradle.jvm.toolchain.JavaToolchainService;
@@ -39,33 +41,34 @@ public abstract class StandaloneJavaLibraryPlugin implements Plugin<Project> {
     public abstract static class Binding implements ProjectTypeBinding {
         @Override
         public void bind(ProjectTypeBindingBuilder builder) {
-            builder.bindProjectType(JAVA_LIBRARY, JavaLibrary.class,
-                    (context, definition, buildModel) -> {
-                        Services services = context.getObjectFactory().newInstance(Services.class);
-                        services.getPluginManager().apply(JavaLibraryPlugin.class);
-                        ((DefaultJavaBuildModel) buildModel).setJavaPluginExtension(services.getProject().getExtensions().getByType(JavaPluginExtension.class));
-
-                        context.getObjectFactory().newInstance(ModelToPluginLinker.class).link(
-                                definition,
-                                buildModel,
-                                services.getPluginManager(),
-                                services.getProject().getConfigurations(),
-                                services.getProject().getTasks()
-                        );
-                    }
-            )
-            .withUnsafeDefinition()
-            .withUnsafeApplyAction()
-            .withBuildModelImplementationType(DefaultJavaBuildModel.class);
+            builder.bindProjectType(JAVA_LIBRARY, JavaLibrary.class, ApplyAction.class)
+                .withUnsafeDefinition()
+                .withUnsafeApplyAction()
+                .withBuildModelImplementationType(DefaultJavaBuildModel.class);
         }
 
-        static abstract class ModelToPluginLinker {
+        @SuppressWarnings("UnstableApiUsage")
+        static abstract class ApplyAction implements ProjectTypeApplyAction<JavaLibrary, JavaBuildModel> {
             @Inject
-            public ModelToPluginLinker() {
+            public ApplyAction() {
             }
 
             @Inject
+            protected abstract PluginManager getPluginManager();
+
+            @Inject
+            protected abstract Project getProject();
+
+            @Inject
             protected abstract JavaToolchainService getJavaToolchainService();
+
+            @Override
+            public void apply(ProjectFeatureApplicationContext context, JavaLibrary definition, JavaBuildModel buildModel) {
+                getPluginManager().apply(JavaLibraryPlugin.class);
+                ((DefaultJavaBuildModel) buildModel).setJavaPluginExtension(getProject().getExtensions().getByType(JavaPluginExtension.class));
+
+                link(definition, buildModel, getPluginManager(), getProject().getConfigurations(), getProject().getTasks());
+            }
 
             private void link(JavaLibrary definition, JavaBuildModel buildModel, PluginManager pluginManager, ConfigurationContainer configurations, TaskContainer tasks) {
                 pluginManager.withPlugin("java", plugin -> {
@@ -75,14 +78,6 @@ public abstract class StandaloneJavaLibraryPlugin implements Plugin<Project> {
                     JvmPluginSupport.linkTestSourceSourceSetDependencies(definition.getTesting().getDependencies(), buildModel.getJavaPluginExtension(), configurations);
                 });
             }
-        }
-
-        interface Services {
-            @Inject
-            PluginManager getPluginManager();
-
-            @Inject
-            Project getProject();
         }
     }
 }

--- a/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/java/checkstyle/CheckstyleSoftwareFeaturePlugin.java
+++ b/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/java/checkstyle/CheckstyleSoftwareFeaturePlugin.java
@@ -9,12 +9,14 @@ import org.gradle.api.artifacts.dsl.DependencyFactory;
 import org.gradle.api.experimental.jvm.JavaBuildModel;
 import org.gradle.api.plugins.quality.Checkstyle;
 import org.gradle.api.plugins.quality.CheckstylePlugin;
-import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.features.annotations.BindsProjectFeature;
+import org.gradle.features.binding.Definition;
+import org.gradle.features.binding.ProjectFeatureApplicationContext;
+import org.gradle.features.binding.ProjectFeatureApplyAction;
 import org.gradle.features.binding.ProjectFeatureBinding;
 import org.gradle.features.binding.ProjectFeatureBindingBuilder;
 import org.gradle.features.file.ProjectFeatureLayout;
@@ -37,71 +39,77 @@ public class CheckstyleSoftwareFeaturePlugin implements Plugin<Project> {
             builder.bindProjectFeature(
                 "checkstyle",
                 ProjectFeatureBindingBuilder.bindingToTargetBuildModel(CheckstyleDefinition.class, JavaBuildModel.class),
-                (context, definition, buildModel, parent) -> {
-                    Services services = context.getObjectFactory().newInstance(Services.class);
-
-                    JavaBuildModel javaBuildModel = context.getBuildModel(parent);
-
-                    buildModel.getCheckstyleVersion().set(definition.getCheckstyleVersion().orElse(CheckstylePlugin.DEFAULT_CHECKSTYLE_VERSION));
-                    buildModel.getConfigDirectory().set(definition.getConfigDirectory().orElse(services.getProjectFeatureLayout().getSettingsDirectory().dir("config")));
-                    buildModel.getConfigFile().set(definition.getConfigFile().orElse(buildModel.getConfigDirectory().file("checkstyle.xml")));
-
-                    linkCheckstyle(buildModel, javaBuildModel, services.getConfigurationRegistrar(), services.getProject().getTasks(), services.getDependencyFactory(), services.getProjectFeatureLayout());
-                }
+                ApplyAction.class
             )
             .withUnsafeApplyAction();
         }
 
-        public static void linkCheckstyle(CheckstyleBuildModel buildModel, JavaBuildModel javaBuildModel, ConfigurationRegistrar configurations, TaskContainer tasks, DependencyFactory dependencyFactory, ProjectFeatureLayout projectLayout) {
-            // Half implementation of org.gradle.checkstyle
-            NamedDomainObjectProvider<DependencyScopeConfiguration> checkstyleTool = configurations.dependencyScope("checkstyleTool", conf -> {
-                conf.getDependencies().addLater(buildModel.getCheckstyleVersion().map(v -> dependencyFactory.create("com.puppycrawl.tools:checkstyle:" + v)));
-            });
-            NamedDomainObjectProvider<ResolvableConfiguration> checkstyleClasspath = configurations.resolvable("checkstyleClasspath", conf -> {
-                conf.extendsFrom(checkstyleTool.get());
-            });
-
-            SourceSetContainer sourceSets = javaBuildModel.getJavaPluginExtension().getSourceSets();
-            buildModel.getClasspath().from(checkstyleClasspath);
-            sourceSets.all(sourceSet -> createCheckstyleForSourceSet(buildModel, sourceSet, tasks, projectLayout));
-        }
-
-        private static void createCheckstyleForSourceSet(CheckstyleBuildModel buildModel, SourceSet sourceSet, TaskContainer tasks, ProjectFeatureLayout projectLayout) {
-            TaskProvider<Checkstyle> checkstyleTask = tasks.register(sourceSet.getTaskName("checkstyle", null), Checkstyle.class, task -> {
-                task.setDescription(String.format("Runs Checkstyle for source set '%s'.", sourceSet.getName()));
-                task.setGroup(LifecycleBasePlugin.VERIFICATION_GROUP);
-
-                task.setSource(sourceSet.getAllJava());
-                task.setClasspath(sourceSet.getRuntimeClasspath());
-
-                task.getConfigDirectory().convention(buildModel.getConfigDirectory());
-                task.setCheckstyleClasspath(buildModel.getClasspath());
-                task.setConfigFile(buildModel.getConfigFile().getAsFile().get());
-
-                task.getReports().getHtml().getRequired().convention(true);
-                task.getReports().getHtml().getOutputLocation().convention(projectLayout.getContextBuildDirectory().map(layout -> layout.file("reports/checkstyle/" + sourceSet.getName() + ".html")));
-
-                task.getReports().getXml().getRequired().convention(task.getReports().getHtml().getRequired());
-                task.getReports().getXml().getOutputLocation().convention(projectLayout.getContextBuildDirectory().map(layout -> layout.file("reports/checkstyle/" + sourceSet.getName() + ".xml")));
-            });
-
-            tasks.named("check").configure(check -> {
-                check.dependsOn(checkstyleTask);
-            });
-        }
-
-        interface Services {
+        @SuppressWarnings("UnstableApiUsage")
+        static abstract class ApplyAction implements ProjectFeatureApplyAction<CheckstyleDefinition, CheckstyleBuildModel, Definition<JavaBuildModel>> {
             @Inject
-            ConfigurationRegistrar getConfigurationRegistrar();
+            public ApplyAction() {
+            }
 
             @Inject
-            ProjectFeatureLayout getProjectFeatureLayout();
+            protected abstract ConfigurationRegistrar getConfigurationRegistrar();
 
             @Inject
-            DependencyFactory getDependencyFactory();
+            protected abstract ProjectFeatureLayout getProjectFeatureLayout();
 
             @Inject
-            Project getProject();
+            protected abstract DependencyFactory getDependencyFactory();
+
+            @Inject
+            protected abstract Project getProject();
+
+            @Override
+            public void apply(ProjectFeatureApplicationContext context, CheckstyleDefinition definition, CheckstyleBuildModel buildModel, Definition<JavaBuildModel> parent) {
+                JavaBuildModel javaBuildModel = context.getBuildModel(parent);
+
+                buildModel.getCheckstyleVersion().set(definition.getCheckstyleVersion().orElse(CheckstylePlugin.DEFAULT_CHECKSTYLE_VERSION));
+                buildModel.getConfigDirectory().set(definition.getConfigDirectory().orElse(getProjectFeatureLayout().getSettingsDirectory().dir("config")));
+                buildModel.getConfigFile().set(definition.getConfigFile().orElse(buildModel.getConfigDirectory().file("checkstyle.xml")));
+
+                linkCheckstyle(buildModel, javaBuildModel, getConfigurationRegistrar(), getProject().getTasks(), getDependencyFactory(), getProjectFeatureLayout());
+            }
+
+            private void linkCheckstyle(CheckstyleBuildModel buildModel, JavaBuildModel javaBuildModel, ConfigurationRegistrar configurations, TaskContainer tasks, DependencyFactory dependencyFactory, ProjectFeatureLayout projectLayout) {
+                // Half implementation of org.gradle.checkstyle
+                NamedDomainObjectProvider<DependencyScopeConfiguration> checkstyleTool = configurations.dependencyScope("checkstyleTool", conf -> {
+                    conf.getDependencies().addLater(buildModel.getCheckstyleVersion().map(v -> dependencyFactory.create("com.puppycrawl.tools:checkstyle:" + v)));
+                });
+                NamedDomainObjectProvider<ResolvableConfiguration> checkstyleClasspath = configurations.resolvable("checkstyleClasspath", conf -> {
+                    conf.extendsFrom(checkstyleTool.get());
+                });
+
+                SourceSetContainer sourceSets = javaBuildModel.getJavaPluginExtension().getSourceSets();
+                buildModel.getClasspath().from(checkstyleClasspath);
+                sourceSets.all(sourceSet -> createCheckstyleForSourceSet(buildModel, sourceSet, tasks, projectLayout));
+            }
+
+            private static void createCheckstyleForSourceSet(CheckstyleBuildModel buildModel, SourceSet sourceSet, TaskContainer tasks, ProjectFeatureLayout projectLayout) {
+                TaskProvider<Checkstyle> checkstyleTask = tasks.register(sourceSet.getTaskName("checkstyle", null), Checkstyle.class, task -> {
+                    task.setDescription(String.format("Runs Checkstyle for source set '%s'.", sourceSet.getName()));
+                    task.setGroup(LifecycleBasePlugin.VERIFICATION_GROUP);
+
+                    task.setSource(sourceSet.getAllJava());
+                    task.setClasspath(sourceSet.getRuntimeClasspath());
+
+                    task.getConfigDirectory().convention(buildModel.getConfigDirectory());
+                    task.setCheckstyleClasspath(buildModel.getClasspath());
+                    task.setConfigFile(buildModel.getConfigFile().getAsFile().get());
+
+                    task.getReports().getHtml().getRequired().convention(true);
+                    task.getReports().getHtml().getOutputLocation().convention(projectLayout.getContextBuildDirectory().map(layout -> layout.file("reports/checkstyle/" + sourceSet.getName() + ".html")));
+
+                    task.getReports().getXml().getRequired().convention(task.getReports().getHtml().getRequired());
+                    task.getReports().getXml().getOutputLocation().convention(projectLayout.getContextBuildDirectory().map(layout -> layout.file("reports/checkstyle/" + sourceSet.getName() + ".xml")));
+                });
+
+                tasks.named("check").configure(check -> {
+                    check.dependsOn(checkstyleTask);
+                });
+            }
         }
     }
 }

--- a/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/jvm/StandaloneJvmApplicationPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/jvm/StandaloneJvmApplicationPlugin.java
@@ -17,6 +17,8 @@ import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.features.annotations.BindsProjectType;
+import org.gradle.features.binding.ProjectFeatureApplicationContext;
+import org.gradle.features.binding.ProjectTypeApplyAction;
 import org.gradle.features.binding.ProjectTypeBinding;
 import org.gradle.features.binding.ProjectTypeBindingBuilder;
 import org.gradle.features.file.ProjectFeatureLayout;
@@ -43,93 +45,92 @@ public abstract class StandaloneJvmApplicationPlugin implements Plugin<Project> 
     static class Binding implements ProjectTypeBinding {
         @Override
         public void bind(ProjectTypeBindingBuilder builder) {
-            builder.bindProjectType(JVM_APPLICATION, JvmApplication.class,
-                    (context, definition, buildModel) -> {
-                        Services services = context.getObjectFactory().newInstance(Services.class);
-                        services.getPluginManager().apply(ApplicationPlugin.class);
-                        CliExecutablesSupport.configureRunTasks(services.getTaskRegistrar(), buildModel);
-                        ((DefaultJavaApplicationBuildModel) buildModel).setJavaPluginExtension(
-                                services.getProject().getExtensions().getByType(JavaPluginExtension.class)
-                        );
-                        ((DefaultJavaApplicationBuildModel) buildModel).setJavaApplicationExtension(
-                                services.getProject().getExtensions().getByType(JavaApplication.class)
-                        );
-
-                        context.getObjectFactory().newInstance(ModelToPluginLinker.class).link(
-                                definition,
-                                buildModel,
-                                services.getProject().getConfigurations(),
-                                services.getProject().getTasks(),
-                                services.getProjectFeatureLayout(),
-                                services.getProviderFactory(),
-                                services.getDependencyFactory(),
-                                JavaPluginHelper.getJavaComponent(services.getProject()).getMainFeature().getSourceSet()
-                        );
-                    }
-            )
-            .withUnsafeDefinition()
-            .withUnsafeApplyAction()
-            .withBuildModelImplementationType(DefaultJavaApplicationBuildModel.class);
+            builder.bindProjectType(JVM_APPLICATION, JvmApplication.class, ApplyAction.class)
+                    .withUnsafeDefinition()
+                    .withUnsafeApplyAction()
+                    .withBuildModelImplementationType(DefaultJavaApplicationBuildModel.class);
         }
 
-        interface Services {
+        @SuppressWarnings("UnstableApiUsage")
+        static abstract class ApplyAction implements ProjectTypeApplyAction<JvmApplication, JavaApplicationBuildModel> {
             @Inject
-            PluginManager getPluginManager();
-
-            @Inject
-            TaskRegistrar getTaskRegistrar();
-
-            @Inject
-            ProjectFeatureLayout getProjectFeatureLayout();
+            public ApplyAction() {
+            }
 
             @Inject
-            ProviderFactory getProviderFactory();
+            protected abstract PluginManager getPluginManager();
 
             @Inject
-            DependencyFactory getDependencyFactory();
+            protected abstract TaskRegistrar getTaskRegistrar();
 
             @Inject
-            Project getProject();
-        }
-    }
+            protected abstract ProjectFeatureLayout getProjectFeatureLayout();
 
-    static abstract class ModelToPluginLinker {
-        @Inject
-        public ModelToPluginLinker() {
-        }
+            @Inject
+            protected abstract ProviderFactory getProviderFactory();
 
-        @Inject
-        protected abstract JavaToolchainService getJavaToolchainService();
+            @Inject
+            protected abstract DependencyFactory getDependencyFactory();
 
-        private void link(
-                JvmApplication dslModel,
-                JavaApplicationBuildModel buildModel,
-                ConfigurationContainer configurations,
-                TaskContainer tasks,
-                ProjectFeatureLayout projectLayout,
-                ProviderFactory providers,
-                DependencyFactory dependencyFactory,
-                SourceSet commonSources) {
+            @Inject
+            protected abstract Project getProject();
 
-            JvmPluginSupport.setupCommonSourceSet(commonSources, projectLayout);
-            JvmPluginSupport.linkSourceSetToDependencies(commonSources, dslModel.getDependencies(), configurations);
+            @Inject
+            protected abstract JavaToolchainService getJavaToolchainService();
 
-            JvmPluginSupport.linkJavaVersion(dslModel, buildModel.getJavaPluginExtension(), providers);
-            JvmPluginSupport.linkApplicationMainClass(dslModel, buildModel.getJavaApplicationExtension());
-            dslModel.getTargets().getStore().withType(JavaTarget.class).all(target -> {
-                SourceSet sourceSet = JvmPluginSupport.createTargetSourceSet(target, commonSources, getJavaToolchainService(), buildModel.getJavaPluginExtension(), tasks, configurations, dependencyFactory);
+            @Override
+            public void apply(ProjectFeatureApplicationContext context, JvmApplication definition, JavaApplicationBuildModel buildModel) {
+                getPluginManager().apply(ApplicationPlugin.class);
+                CliExecutablesSupport.configureRunTasks(getTaskRegistrar(), buildModel);
+                ((DefaultJavaApplicationBuildModel) buildModel).setJavaPluginExtension(
+                        getProject().getExtensions().getByType(JavaPluginExtension.class)
+                );
+                ((DefaultJavaApplicationBuildModel) buildModel).setJavaApplicationExtension(
+                        getProject().getExtensions().getByType(JavaApplication.class)
+                );
 
-                // Link dependencies to DSL
-                JvmPluginSupport.linkSourceSetToDependencies(sourceSet, target.getDependencies(), configurations);
+                link(
+                        definition,
+                        buildModel,
+                        getProject().getConfigurations(),
+                        getProject().getTasks(),
+                        getProjectFeatureLayout(),
+                        getProviderFactory(),
+                        getDependencyFactory(),
+                        JavaPluginHelper.getJavaComponent(getProject()).getMainFeature().getSourceSet()
+                );
+            }
 
-                // Create a run task
-                TaskProvider<JavaExec> runTask = tasks.register(sourceSet.getTaskName("run", null), JavaExec.class, task -> {
-                    task.getMainClass().set(dslModel.getMainClass());
-                    task.getJvmArguments().set(dslModel.getJvmArguments());
-                    task.setClasspath(sourceSet.getRuntimeClasspath());
+            private void link(
+                    JvmApplication dslModel,
+                    JavaApplicationBuildModel buildModel,
+                    ConfigurationContainer configurations,
+                    TaskContainer tasks,
+                    ProjectFeatureLayout projectLayout,
+                    ProviderFactory providers,
+                    DependencyFactory dependencyFactory,
+                    SourceSet commonSources) {
+
+                JvmPluginSupport.setupCommonSourceSet(commonSources, projectLayout);
+                JvmPluginSupport.linkSourceSetToDependencies(commonSources, dslModel.getDependencies(), configurations);
+
+                JvmPluginSupport.linkJavaVersion(dslModel, buildModel.getJavaPluginExtension(), providers);
+                JvmPluginSupport.linkApplicationMainClass(dslModel, buildModel.getJavaApplicationExtension());
+                dslModel.getTargets().getStore().withType(JavaTarget.class).all(target -> {
+                    SourceSet sourceSet = JvmPluginSupport.createTargetSourceSet(target, commonSources, getJavaToolchainService(), buildModel.getJavaPluginExtension(), tasks, configurations, dependencyFactory);
+
+                    // Link dependencies to DSL
+                    JvmPluginSupport.linkSourceSetToDependencies(sourceSet, target.getDependencies(), configurations);
+
+                    // Create a run task
+                    TaskProvider<JavaExec> runTask = tasks.register(sourceSet.getTaskName("run", null), JavaExec.class, task -> {
+                        task.getMainClass().set(dslModel.getMainClass());
+                        task.getJvmArguments().set(dslModel.getJvmArguments());
+                        task.setClasspath(sourceSet.getRuntimeClasspath());
+                    });
+                    buildModel.getRunTasks().add(runTask);
                 });
-                buildModel.getRunTasks().add(runTask);
-            });
+            }
         }
     }
 }

--- a/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/jvm/StandaloneJvmLibraryPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-jvm/src/main/java/org/gradle/api/experimental/jvm/StandaloneJvmLibraryPlugin.java
@@ -13,6 +13,8 @@ import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.features.annotations.BindsProjectType;
+import org.gradle.features.binding.ProjectFeatureApplicationContext;
+import org.gradle.features.binding.ProjectTypeApplyAction;
 import org.gradle.features.binding.ProjectTypeBinding;
 import org.gradle.features.binding.ProjectTypeBindingBuilder;
 import org.gradle.features.file.ProjectFeatureLayout;
@@ -39,88 +41,86 @@ public abstract class StandaloneJvmLibraryPlugin implements Plugin<Project> {
     static class Binding implements ProjectTypeBinding {
         @Override
         public void bind(ProjectTypeBindingBuilder builder) {
-            builder.bindProjectType(JVM_LIBRARY, JvmLibrary.class,
-                    (context, definition, buildModel) -> {
-                        Services services = context.getObjectFactory().newInstance(Services.class);
-
-                        services.getPluginManager().apply(JavaLibraryPlugin.class);
-                        ((DefaultJavaBuildModel) buildModel).setJavaPluginExtension(
-                                services.getProject().getExtensions().getByType(JavaPluginExtension.class)
-                        );
-
-                        context.getObjectFactory().newInstance(ModelToPluginLinker.class).link(
-                                definition,
-                                buildModel,
-                                services.getConfigurationRegistrar(),
-                                services.getProject().getConfigurations(),
-                                services.getProject().getTasks(),
-                                services.getProjectFeatureLayout(),
-                                services.getProviderFactory(),
-                                services.getDependencyFactory(),
-                                JavaPluginHelper.getJavaComponent(services.getProject()).getMainFeature().getSourceSet()
-                        );
-                    }
-            )
-            .withUnsafeDefinition()
-            .withUnsafeApplyAction()
-            .withBuildModelImplementationType(DefaultJavaBuildModel.class);
+            builder.bindProjectType(JVM_LIBRARY, JvmLibrary.class, ApplyAction.class)
+                    .withUnsafeDefinition()
+                    .withUnsafeApplyAction()
+                    .withBuildModelImplementationType(DefaultJavaBuildModel.class);
         }
 
-        interface Services {
+        @SuppressWarnings("UnstableApiUsage")
+        static abstract class ApplyAction implements ProjectTypeApplyAction<JvmLibrary, JavaBuildModel> {
             @Inject
-            PluginManager getPluginManager();
-
-            @Inject
-            ConfigurationRegistrar getConfigurationRegistrar();
-
-            @Inject
-            ProjectFeatureLayout getProjectFeatureLayout();
+            public ApplyAction() {
+            }
 
             @Inject
-            ProviderFactory getProviderFactory();
+            protected abstract PluginManager getPluginManager();
 
             @Inject
-            DependencyFactory getDependencyFactory();
+            protected abstract ConfigurationRegistrar getConfigurationRegistrar();
 
             @Inject
-            Project getProject();
-        }
-    }
+            protected abstract ProjectFeatureLayout getProjectFeatureLayout();
 
-    static abstract class ModelToPluginLinker {
-        @Inject
-        public ModelToPluginLinker() {
-        }
+            @Inject
+            protected abstract ProviderFactory getProviderFactory();
 
-        @Inject
-        protected abstract JavaToolchainService getJavaToolchainService();
+            @Inject
+            protected abstract DependencyFactory getDependencyFactory();
 
-        private void link(
-                JvmLibrary dslModel,
-                JavaBuildModel buildModel,
-                ConfigurationRegistrar configurationRegistrar,
-                ConfigurationContainer configurations,
-                TaskContainer tasks,
-                ProjectFeatureLayout projectLayout,
-                ProviderFactory providers,
-                DependencyFactory dependencyFactory,
-                SourceSet commonSources) {
+            @Inject
+            protected abstract Project getProject();
 
-            JvmPluginSupport.setupCommonSourceSet(commonSources, projectLayout);
-            JvmPluginSupport.linkSourceSetToDependencies(commonSources, dslModel.getDependencies(), configurations);
+            @Inject
+            protected abstract JavaToolchainService getJavaToolchainService();
 
-            JvmPluginSupport.linkJavaVersion(dslModel, buildModel.getJavaPluginExtension(), providers);
+            @Override
+            public void apply(ProjectFeatureApplicationContext context, JvmLibrary definition, JavaBuildModel buildModel) {
+                getPluginManager().apply(JavaLibraryPlugin.class);
+                ((DefaultJavaBuildModel) buildModel).setJavaPluginExtension(
+                        getProject().getExtensions().getByType(JavaPluginExtension.class)
+                );
 
-            dslModel.getTargets().getStore().withType(JavaTarget.class).all(target -> {
-                SourceSet sourceSet = JvmPluginSupport.createTargetSourceSet(target, commonSources, getJavaToolchainService(), buildModel.getJavaPluginExtension(), tasks, configurations, dependencyFactory);
+                link(
+                        definition,
+                        buildModel,
+                        getConfigurationRegistrar(),
+                        getProject().getConfigurations(),
+                        getProject().getTasks(),
+                        getProjectFeatureLayout(),
+                        getProviderFactory(),
+                        getDependencyFactory(),
+                        JavaPluginHelper.getJavaComponent(getProject()).getMainFeature().getSourceSet()
+                );
+            }
 
-                // Link dependencies to DSL
-                JvmPluginSupport.linkSourceSetToDependencies(sourceSet, target.getDependencies(), configurations);
+            private void link(
+                    JvmLibrary dslModel,
+                    JavaBuildModel buildModel,
+                    ConfigurationRegistrar configurationRegistrar,
+                    ConfigurationContainer configurations,
+                    TaskContainer tasks,
+                    ProjectFeatureLayout projectLayout,
+                    ProviderFactory providers,
+                    DependencyFactory dependencyFactory,
+                    SourceSet commonSources) {
 
-                // Extend common dependencies
-                configurations.getByName(sourceSet.getApiConfigurationName())
-                        .extendsFrom(configurations.getByName(commonSources.getApiConfigurationName()));
-            });
+                JvmPluginSupport.setupCommonSourceSet(commonSources, projectLayout);
+                JvmPluginSupport.linkSourceSetToDependencies(commonSources, dslModel.getDependencies(), configurations);
+
+                JvmPluginSupport.linkJavaVersion(dslModel, buildModel.getJavaPluginExtension(), providers);
+
+                dslModel.getTargets().getStore().withType(JavaTarget.class).all(target -> {
+                    SourceSet sourceSet = JvmPluginSupport.createTargetSourceSet(target, commonSources, getJavaToolchainService(), buildModel.getJavaPluginExtension(), tasks, configurations, dependencyFactory);
+
+                    // Link dependencies to DSL
+                    JvmPluginSupport.linkSourceSetToDependencies(sourceSet, target.getDependencies(), configurations);
+
+                    // Extend common dependencies
+                    configurations.getByName(sourceSet.getApiConfigurationName())
+                            .extendsFrom(configurations.getByName(commonSources.getApiConfigurationName()));
+                });
+            }
         }
     }
 }

--- a/unified-prototype/unified-plugin/plugin-jvm/src/main/resources/templates/java-application/settings.gradle.dcl
+++ b/unified-prototype/unified-plugin/plugin-jvm/src/main/resources/templates/java-application/settings.gradle.dcl
@@ -5,7 +5,7 @@ pluginManagement {
 }
 
 plugins {
-    id("org.gradle.experimental.jvm-ecosystem").version("0.1.58")
+    id("org.gradle.experimental.jvm-ecosystem").version("0.1.59")
 }
 
 rootProject.name = "example-java-app"

--- a/unified-prototype/unified-plugin/plugin-kmp/src/main/java/org/gradle/api/experimental/kmp/StandaloneKmpApplicationPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-kmp/src/main/java/org/gradle/api/experimental/kmp/StandaloneKmpApplicationPlugin.java
@@ -19,6 +19,8 @@ import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.testing.Test;
 import org.gradle.features.annotations.BindsProjectType;
+import org.gradle.features.binding.ProjectFeatureApplicationContext;
+import org.gradle.features.binding.ProjectTypeApplyAction;
 import org.gradle.features.binding.ProjectTypeBinding;
 import org.gradle.features.binding.ProjectTypeBindingBuilder;
 import org.gradle.features.file.ProjectFeatureLayout;
@@ -51,196 +53,200 @@ public abstract class StandaloneKmpApplicationPlugin implements Plugin<Project> 
     static class Binding implements ProjectTypeBinding {
         @Override
         public void bind(ProjectTypeBindingBuilder builder) {
-            builder.bindProjectType(KOTLIN_APPLICATION, KmpApplication.class,
-                    (context, definition, buildModel) -> {
-                        Services services = context.getObjectFactory().newInstance(Services.class);
+            builder.bindProjectType(KOTLIN_APPLICATION, KmpApplication.class, ApplyAction.class)
+                .withUnsafeDefinition()
+                .withUnsafeApplyAction()
+                .withBuildModelImplementationType(DefaultKotlinMultiplatformBuildModel.class);
+        }
 
-                        // Set conventional custom test suit locations as src/<SUITE_NAME>
-                        definition.getTargetsContainer().getStore().withType(KmpApplicationJvmTarget.class).all(target -> {
-                            target.getTesting().getTestSuites().forEach((name, testSuite) -> {
-                                Directory srcRoot = services.getProjectFeatureLayout().getProjectDirectory().dir("src/jvm" + WordUtils.capitalize(name));
-                                testSuite.getSourceRoot().convention(srcRoot);
+        @SuppressWarnings({"UnstableApiUsage", "CodeBlock2Expr"})
+        static abstract class ApplyAction implements ProjectTypeApplyAction<KmpApplication, KotlinMultiplatformBuildModel> {
+            @Inject
+            public ApplyAction() {
+            }
+
+            @Inject
+            protected abstract PluginManager getPluginManager();
+
+            @Inject
+            protected abstract TaskRegistrar getTaskRegistrar();
+
+            @Inject
+            protected abstract ProjectFeatureLayout getProjectFeatureLayout();
+
+            @Inject
+            protected abstract ObjectFactory getObjectFactory();
+
+            @Inject
+            protected abstract Project getProject();
+
+            @Override
+            public void apply(ProjectFeatureApplicationContext context, KmpApplication definition, KotlinMultiplatformBuildModel buildModel) {
+                // Set conventional custom test suit locations as src/<SUITE_NAME>
+                definition.getTargetsContainer().getStore().withType(KmpApplicationJvmTarget.class).all(target -> {
+                    target.getTesting().getTestSuites().forEach((name, testSuite) -> {
+                        Directory srcRoot = getProjectFeatureLayout().getProjectDirectory().dir("src/jvm" + WordUtils.capitalize(name));
+                        testSuite.getSourceRoot().convention(srcRoot);
+                    });
+                });
+
+                // Apply the official KMP plugin
+                getPluginManager().apply("org.jetbrains.kotlin.multiplatform");
+                CliExecutablesSupport.configureRunTasks(getTaskRegistrar(), buildModel);
+
+                ((DefaultKotlinMultiplatformBuildModel) buildModel).setKotlinMultiplatformExtension(
+                        getProject().getExtensions().getByType(KotlinMultiplatformExtension.class)
+                );
+                buildModel.getGroup().convention(definition.getGroup());
+                buildModel.getVersion().convention(definition.getVersion());
+
+                // This stuff can be wired up immediately
+                linkDslModelToPluginLazy(definition, buildModel, getProject().getConfigurations(), getProject().getTasks());
+                // This stuff must be wired up in an afterEvaluate block
+                getProject().afterEvaluate(p -> {
+                    ifPresent(buildModel.getGroup(), p::setGroup);
+                    ifPresent(buildModel.getVersion(), p::setVersion);
+                    linkDslModelToPlugin(definition, buildModel, getProject().getConfigurations(), getProject().getTasks(), getObjectFactory());
+                });
+            }
+
+            /**
+             * Performs linking actions that must occur within an afterEvaluate block.
+             */
+            private static void linkDslModelToPlugin(KmpApplication definition, KotlinMultiplatformBuildModel buildModel, ConfigurationContainer configurations, TaskContainer tasks, ObjectFactory objects) {
+                KotlinMultiplatformExtension kotlin = buildModel.getKotlinMultiplatformExtension();
+
+                // Link common properties
+                kotlin.getSourceSets().configureEach(sourceSet -> {
+                    sourceSet.languageSettings(languageSettings -> {
+                        ifPresent(definition.getLanguageVersion(), languageSettings::setLanguageVersion);
+                        ifPresent(definition.getLanguageVersion(), languageSettings::setApiVersion);
+                    });
+                });
+
+                // Link Native targets
+                definition.getTargetsContainer().getStore().withType(KmpApplicationNativeTarget.class).all(target -> {
+                    kotlin.macosArm64(target.getName(), kotlinTarget -> {
+                        kotlinTarget.binaries(nativeBinaries -> {
+                            nativeBinaries.executable(executable -> {
+                                executable.entryPoint(target.getEntryPoint().get());
+                                TaskProvider<AbstractExecTask<?>> runTask = executable.getRunTaskProvider();
+                                if (runTask != null) {
+                                    buildModel.getRunTasks().add(runTask);
+                                }
                             });
                         });
+                    });
+                });
 
-                        // Apply the official KMP plugin
-                        services.getPluginManager().apply("org.jetbrains.kotlin.multiplatform");
-                        CliExecutablesSupport.configureRunTasks(services.getTaskRegistrar(), buildModel);
+                // Add common JVM testing dependencies if the JVM target is a part of this build
+                if (null != kotlin.getSourceSets().findByName("jvmTest")) {
+                    KotlinPluginSupport.linkSourceSetToDependencies(configurations, kotlin.getSourceSets().getByName("jvmTest"), definition.getTargetsContainer().getStore().getByName("jvm").getTesting().getDependencies());
+                    tasks.withType(KotlinJvmTest.class).forEach(Test::useJUnitPlatform);
+                }
 
-                        ((DefaultKotlinMultiplatformBuildModel)buildModel).setKotlinMultiplatformExtension(
-                                services.getProject().getExtensions().getByType(KotlinMultiplatformExtension.class)
+                // Create all custom JVM test suites
+                definition.getTargetsContainer().getStore().withType(KmpApplicationJvmTarget.class).all(target -> {
+                    kotlin.jvm(target.getName(), kotlinTarget -> {
+                        target.getTesting().getTestSuites().forEach((name, testSuite) -> {
+                            // Create a new compilation for the test suite
+                            String suiteCompilationName = "suite" + WordUtils.capitalize(name) + "Compilation";
+                            // Note: "register" won't work here, lazy APIs not working right on this container, just create
+                            KotlinJvmCompilation suiteCompilation = kotlinTarget.getCompilations().create(suiteCompilationName, compilation -> {
+                                compilation.associateWith(kotlin.jvm().compilations.getByName("test"));
+                                compilation.getDefaultSourceSet().getKotlin().srcDir(testSuite.getSourceRoot());
+
+                                // Add testing dependencies specific to each JVM test suite
+                                KotlinPluginSupport.linkSourceSetToDependencies(
+                                        configurations,
+                                        compilation.getDefaultSourceSet(),
+                                        testSuite.getDependencies()
+                                );
+                            });
+
+                            // Create test task for the new compilation
+                            String suiteTestTaskName = "suite" + WordUtils.capitalize(name) + "Test";
+                            Provider<KotlinJvmTest> suiteTestTask = tasks.register(suiteTestTaskName, KotlinJvmTest.class, task -> {
+                                task.setTargetName(suiteCompilation.getTarget().getName());
+                                task.useJUnitPlatform();
+                                task.dependsOn(suiteCompilation.getCompileTaskProvider());
+                                task.setTestClassesDirs(suiteCompilation.getCompileTaskProvider().get().getOutputs().getFiles());
+
+                                ConfigurableFileCollection testRuntimeClasspath = objects.fileCollection();
+                                testRuntimeClasspath.from(suiteCompilation.getCompileTaskProvider().get().getOutputs().getFiles());
+                                testRuntimeClasspath.from(configurations.named(suiteCompilation.getRuntimeDependencyConfigurationName()).get());
+                                task.setClasspath(testRuntimeClasspath);
+                            });
+
+                            // New tests are included in jvm tests
+                            tasks.named("jvmTest").configure(task -> {
+                                task.dependsOn(suiteTestTask);
+                            });
+                        });
+                    });
+                });
+            }
+
+            /**
+             * Performs linking actions that do not need to occur within an afterEvaluate block.
+             */
+            @SuppressWarnings("deprecation")
+            private static void linkDslModelToPluginLazy(KmpApplication definition, KotlinMultiplatformBuildModel buildModel, ConfigurationContainer configurations, TaskContainer tasks) {
+                KotlinMultiplatformExtension kotlin = buildModel.getKotlinMultiplatformExtension();
+
+                // Link common dependencies
+                KotlinPluginSupport.linkSourceSetToDependencies(configurations, kotlin.getSourceSets().getByName("commonMain"), definition.getDependencies());
+
+                // Link JVM targets
+                definition.getTargetsContainer().getStore().withType(KmpApplicationJvmTarget.class).all(target -> {
+                    kotlin.jvm(target.getName(), kotlinTarget -> {
+                        KotlinPluginSupport.linkSourceSetToDependencies(
+                                configurations,
+                                kotlinTarget.getCompilations().getByName("main").getDefaultSourceSet(),
+                                target.getDependencies()
                         );
-                        buildModel.getGroup().convention(definition.getGroup());
-                        buildModel.getVersion().convention(definition.getVersion());
-
-                        // This stuff can be wired up immediately
-                        linkDslModelToPluginLazy(definition, buildModel, services.getProject().getConfigurations(), services.getProject().getTasks());
-                        // This stuff must be wired up in an afterEvaluate block
-                        services.getProject().afterEvaluate(p -> {
-                            ifPresent(buildModel.getGroup(), p::setGroup);
-                            ifPresent(buildModel.getVersion(), p::setVersion);
-                            linkDslModelToPlugin(definition, buildModel, services.getProject().getConfigurations(), services.getProject().getTasks(), services.getObjectFactory());
+                        kotlinTarget.getCompilations().configureEach(compilation -> {
+                            compilation.getCompilerOptions().getOptions().getJvmTarget().set(target.getJdkVersion().map(value -> JvmTarget.Companion.fromTarget(String.valueOf(value))));
                         });
-                    }
-            )
-            .withUnsafeDefinition()
-            .withUnsafeApplyAction()
-            .withBuildModelImplementationType(DefaultKotlinMultiplatformBuildModel.class);
-        }
-
-        /**
-         * Performs linking actions that must occur within an afterEvaluate block.
-         */
-        private static void linkDslModelToPlugin(KmpApplication definition, KotlinMultiplatformBuildModel buildModel, ConfigurationContainer configurations, TaskContainer tasks, ObjectFactory objects) {
-            KotlinMultiplatformExtension kotlin = buildModel.getKotlinMultiplatformExtension();
-
-            // Link common properties
-            kotlin.getSourceSets().configureEach(sourceSet -> {
-                sourceSet.languageSettings(languageSettings -> {
-                    ifPresent(definition.getLanguageVersion(), languageSettings::setLanguageVersion);
-                    ifPresent(definition.getLanguageVersion(), languageSettings::setApiVersion);
-                });
-            });
-
-            // Link Native targets
-            definition.getTargetsContainer().getStore().withType(KmpApplicationNativeTarget.class).all(target -> {
-                kotlin.macosArm64(target.getName(), kotlinTarget -> {
-                    kotlinTarget.binaries(nativeBinaries -> {
-                        nativeBinaries.executable(executable -> {
-                            executable.entryPoint(target.getEntryPoint().get());
-                            TaskProvider<AbstractExecTask<?>> runTask = executable.getRunTaskProvider();
-                            if (runTask != null) {
-                                buildModel.getRunTasks().add(runTask);
-                            }
+                        kotlinTarget.mainRun(kotlinJvmRunDsl -> {
+                            kotlinJvmRunDsl.getMainClass().set(target.getMainClass());
+                            // The task is not registered until this block of code runs, but the block is deferred until some arbitrary point in time
+                            // So, wire up the task when this block runs
+                            buildModel.getRunTasks().add(tasks.named(target.getName() + "Run"));
+                            return Unit.INSTANCE;
                         });
                     });
                 });
-            });
 
-            // Add common JVM testing dependencies if the JVM target is a part of this build
-            if (null != kotlin.getSourceSets().findByName("jvmTest")) {
-                KotlinPluginSupport.linkSourceSetToDependencies(configurations, kotlin.getSourceSets().getByName("jvmTest"), definition.getTargetsContainer().getStore().getByName("jvm").getTesting().getDependencies());
-                tasks.withType(KotlinJvmTest.class).forEach(Test::useJUnitPlatform);
+                // Link JS targets
+                definition.getTargetsContainer().getStore().withType(KmpApplicationNodeJsTarget.class).all(target -> {
+                    kotlin.js(target.getName(), kotlinTarget -> {
+                        kotlinTarget.nodejs();
+                        KotlinPluginSupport.linkSourceSetToDependencies(
+                                configurations,
+                                kotlinTarget.getCompilations().getByName("main").getDefaultSourceSet(),
+                                target.getDependencies()
+                        );
+                    });
+                });
+
+                // Link Native targets
+                definition.getTargetsContainer().getStore().withType(KmpApplicationNativeTarget.class).all(target -> {
+                    kotlin.macosArm64(target.getName(), kotlinTarget -> {
+                        KotlinPluginSupport.linkSourceSetToDependencies(
+                                configurations,
+                                kotlinTarget.getCompilations().getByName("main").getDefaultSourceSet(),
+                                target.getDependencies()
+                        );
+                    });
+                });
             }
 
-            // Create all custom JVM test suites
-            definition.getTargetsContainer().getStore().withType(KmpApplicationJvmTarget.class).all(target -> {
-                kotlin.jvm(target.getName(), kotlinTarget -> {
-                    target.getTesting().getTestSuites().forEach((name, testSuite) -> {
-                        // Create a new compilation for the test suite
-                        String suiteCompilationName = "suite" + WordUtils.capitalize(name) + "Compilation";
-                        // Note: "register" won't work here, lazy APIs not working right on this container, just create
-                        KotlinJvmCompilation suiteCompilation = kotlinTarget.getCompilations().create(suiteCompilationName, compilation -> {
-                            compilation.associateWith(kotlin.jvm().compilations.getByName("test"));
-                            compilation.getDefaultSourceSet().getKotlin().srcDir(testSuite.getSourceRoot());
-
-                            // Add testing dependencies specific to each JVM test suite
-                            KotlinPluginSupport.linkSourceSetToDependencies(
-                                    configurations,
-                                    compilation.getDefaultSourceSet(),
-                                    testSuite.getDependencies()
-                            );
-                        });
-
-                        // Create test task for the new compilation
-                        String suiteTestTaskName = "suite" +  WordUtils.capitalize(name) + "Test";
-                        Provider<KotlinJvmTest> suiteTestTask = tasks.register(suiteTestTaskName, KotlinJvmTest.class, task -> {
-                            task.setTargetName(suiteCompilation.getTarget().getName());
-                            task.useJUnitPlatform();
-                            task.dependsOn(suiteCompilation.getCompileTaskProvider());
-                            task.setTestClassesDirs(suiteCompilation.getCompileTaskProvider().get().getOutputs().getFiles());
-
-                            ConfigurableFileCollection testRuntimeClasspath = objects.fileCollection();
-                            testRuntimeClasspath.from(suiteCompilation.getCompileTaskProvider().get().getOutputs().getFiles());
-                            testRuntimeClasspath.from(configurations.named(suiteCompilation.getRuntimeDependencyConfigurationName()).get());
-                            task.setClasspath(testRuntimeClasspath);
-                        });
-
-                        // New tests are included in jvm tests
-                        tasks.named("jvmTest").configure(task -> {
-                            task.dependsOn(suiteTestTask);
-                        });
-                    });
-                });
-            });
-        }
-
-        /**
-         * Performs linking actions that do not need to occur within an afterEvaluate block.
-         */
-        @SuppressWarnings("deprecation")
-        private static void linkDslModelToPluginLazy(KmpApplication definition, KotlinMultiplatformBuildModel buildModel, ConfigurationContainer configurations, TaskContainer tasks) {
-            KotlinMultiplatformExtension kotlin = buildModel.getKotlinMultiplatformExtension();
-
-            // Link common dependencies
-            KotlinPluginSupport.linkSourceSetToDependencies(configurations, kotlin.getSourceSets().getByName("commonMain"), definition.getDependencies());
-
-            // Link JVM targets
-            definition.getTargetsContainer().getStore().withType(KmpApplicationJvmTarget.class).all(target -> {
-                kotlin.jvm(target.getName(), kotlinTarget -> {
-                    KotlinPluginSupport.linkSourceSetToDependencies(
-                            configurations,
-                            kotlinTarget.getCompilations().getByName("main").getDefaultSourceSet(),
-                            target.getDependencies()
-                    );
-                    kotlinTarget.getCompilations().configureEach(compilation -> {
-                        compilation.getCompilerOptions().getOptions().getJvmTarget().set(target.getJdkVersion().map(value -> JvmTarget.Companion.fromTarget(String.valueOf(value))));
-                    });
-                    kotlinTarget.mainRun(kotlinJvmRunDsl -> {
-                        kotlinJvmRunDsl.getMainClass().set(target.getMainClass());
-                        // The task is not registered until this block of code runs, but the block is deferred until some arbitrary point in time
-                        // So, wire up the task when this block runs
-                        buildModel.getRunTasks().add(tasks.named(target.getName() + "Run"));
-                        return Unit.INSTANCE;
-                    });
-                });
-            });
-
-            // Link JS targets
-            definition.getTargetsContainer().getStore().withType(KmpApplicationNodeJsTarget.class).all(target -> {
-                kotlin.js(target.getName(), kotlinTarget -> {
-                    kotlinTarget.nodejs();
-                    KotlinPluginSupport.linkSourceSetToDependencies(
-                            configurations,
-                            kotlinTarget.getCompilations().getByName("main").getDefaultSourceSet(),
-                            target.getDependencies()
-                    );
-                });
-            });
-
-            // Link Native targets
-            definition.getTargetsContainer().getStore().withType(KmpApplicationNativeTarget.class).all(target -> {
-                kotlin.macosArm64(target.getName(), kotlinTarget -> {
-                    KotlinPluginSupport.linkSourceSetToDependencies(
-                            configurations,
-                            kotlinTarget.getCompilations().getByName("main").getDefaultSourceSet(),
-                            target.getDependencies()
-                    );
-                });
-            });
-        }
-
-        private static <T> void ifPresent(Property<T> property, Action<T> action) {
-            if (property.isPresent()) {
-                action.execute(property.get());
+            private static <T> void ifPresent(Property<T> property, Action<T> action) {
+                if (property.isPresent()) {
+                    action.execute(property.get());
+                }
             }
-        }
-
-        interface Services {
-            @Inject
-            PluginManager getPluginManager();
-
-            @Inject
-            TaskRegistrar getTaskRegistrar();
-
-            @Inject
-            ProjectFeatureLayout getProjectFeatureLayout();
-
-            @Inject
-            ObjectFactory getObjectFactory();
-
-            @Inject
-            Project getProject();
         }
     }
 }

--- a/unified-prototype/unified-plugin/plugin-kmp/src/main/java/org/gradle/api/experimental/kmp/StandaloneKmpLibraryPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-kmp/src/main/java/org/gradle/api/experimental/kmp/StandaloneKmpLibraryPlugin.java
@@ -9,6 +9,8 @@ import org.gradle.api.plugins.PluginManager;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.features.annotations.BindsProjectType;
+import org.gradle.features.binding.ProjectFeatureApplicationContext;
+import org.gradle.features.binding.ProjectTypeApplyAction;
 import org.gradle.features.binding.ProjectTypeBinding;
 import org.gradle.features.binding.ProjectTypeBindingBuilder;
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget;
@@ -38,115 +40,119 @@ public abstract class StandaloneKmpLibraryPlugin implements Plugin<Project> {
     static class Binding implements ProjectTypeBinding {
         @Override
         public void bind(ProjectTypeBindingBuilder builder) {
-            builder.bindProjectType(KOTLIN_LIBRARY, KmpLibrary.class,
-                    (context, definition, buildModel) -> {
-                        Services services = context.getObjectFactory().newInstance(Services.class);
-
-                        // Apply the official KMP plugin
-                        services.getPluginManager().apply("org.jetbrains.kotlin.multiplatform");
-                        ((DefaultKotlinMultiplatformBuildModel)buildModel).setKotlinMultiplatformExtension(
-                                services.getProject().getExtensions().getByType(KotlinMultiplatformExtension.class)
-                        );
-                        buildModel.getGroup().convention(definition.getGroup());
-                        buildModel.getVersion().convention(definition.getVersion());
-
-                        // This stuff can be wired up immediately
-                        linkDslModelToPluginLazy(definition, buildModel, services.getProject().getConfigurations());
-                        // This stuff must be wired up in an afterEvaluate block
-                        services.getProject().afterEvaluate(p -> {
-                            ifPresent(buildModel.getGroup(), p::setGroup);
-                            ifPresent(buildModel.getVersion(), p::setVersion);
-                            linkDslModelToPlugin(definition, buildModel, p.getTasks());
-                        });
-                    }
-            )
-            .withUnsafeDefinition()
-            .withUnsafeApplyAction()
-            .withBuildModelImplementationType(DefaultKotlinMultiplatformBuildModel.class);
+            builder.bindProjectType(KOTLIN_LIBRARY, KmpLibrary.class, ApplyAction.class)
+                .withUnsafeDefinition()
+                .withUnsafeApplyAction()
+                .withBuildModelImplementationType(DefaultKotlinMultiplatformBuildModel.class);
         }
 
-        /**
-         * Performs linking actions that must occur within an afterEvaluate block.
-         */
-        private static void linkDslModelToPlugin(KmpLibrary definition, KotlinMultiplatformBuildModel buildModel, TaskContainer tasks) {
-            KotlinMultiplatformExtension kotlin = buildModel.getKotlinMultiplatformExtension();
+        @SuppressWarnings("UnstableApiUsage")
+        static abstract class ApplyAction implements ProjectTypeApplyAction<KmpLibrary, KotlinMultiplatformBuildModel> {
+            @Inject
+            public ApplyAction() {
+            }
 
-            // Link common properties
-            kotlin.getSourceSets().configureEach(sourceSet -> {
-                sourceSet.languageSettings(languageSettings -> {
-                    ifPresent(definition.getLanguageVersion(), languageSettings::setLanguageVersion);
-                    ifPresent(definition.getLanguageVersion(), languageSettings::setApiVersion);
+            @Inject
+            protected abstract PluginManager getPluginManager();
+
+            @Inject
+            protected abstract Project getProject();
+
+            @Override
+            public void apply(ProjectFeatureApplicationContext context, KmpLibrary definition, KotlinMultiplatformBuildModel buildModel) {
+                // Apply the official KMP plugin
+                getPluginManager().apply("org.jetbrains.kotlin.multiplatform");
+                ((DefaultKotlinMultiplatformBuildModel) buildModel).setKotlinMultiplatformExtension(
+                        getProject().getExtensions().getByType(KotlinMultiplatformExtension.class)
+                );
+                buildModel.getGroup().convention(definition.getGroup());
+                buildModel.getVersion().convention(definition.getVersion());
+
+                // This stuff can be wired up immediately
+                linkDslModelToPluginLazy(definition, buildModel, getProject().getConfigurations());
+                // This stuff must be wired up in an afterEvaluate block
+                getProject().afterEvaluate(p -> {
+                    ifPresent(buildModel.getGroup(), p::setGroup);
+                    ifPresent(buildModel.getVersion(), p::setVersion);
+                    linkDslModelToPlugin(definition, buildModel, p.getTasks());
                 });
-            });
+            }
 
-            // TODO - figure out how to get rid of this task
-            tasks.configureEach(task -> {
-                if (task.getName().equals("jvmRun")) {
-                    task.setEnabled(false);
-                }
-            });
-        }
+            /**
+             * Performs linking actions that must occur within an afterEvaluate block.
+             */
+            private static void linkDslModelToPlugin(KmpLibrary definition, KotlinMultiplatformBuildModel buildModel, TaskContainer tasks) {
+                KotlinMultiplatformExtension kotlin = buildModel.getKotlinMultiplatformExtension();
 
-        /**
-         * Performs linking actions that do not need to occur within an afterEvaluate block.
-         */
-        private static void linkDslModelToPluginLazy(KmpLibrary dslModel, KotlinMultiplatformBuildModel buildModel, ConfigurationContainer configurations) {
-            KotlinMultiplatformExtension kotlin = buildModel.getKotlinMultiplatformExtension();
-
-            // Link common dependencies
-            KotlinPluginSupport.linkSourceSetToDependencies(configurations, kotlin.getSourceSets().getByName("commonMain"), dslModel.getDependencies());
-
-            // Link JVM targets
-            dslModel.getTargetsContainer().getStore().withType(KmpLibraryJvmTarget.class).all(target -> {
-                kotlin.jvm(target.getName(), kotlinTarget -> {
-                    KotlinPluginSupport.linkSourceSetToDependencies(
-                            configurations,
-                            kotlinTarget.getCompilations().getByName("main").getDefaultSourceSet(),
-                            target.getDependencies()
-                    );
-                    kotlinTarget.getCompilations().configureEach(compilation -> {
-                        compilation.getCompilerOptions().getOptions().getJvmTarget().set(target.getJdkVersion().map(value -> JvmTarget.Companion.fromTarget(String.valueOf(value))));
+                // Link common properties
+                kotlin.getSourceSets().configureEach(sourceSet -> {
+                    sourceSet.languageSettings(languageSettings -> {
+                        ifPresent(definition.getLanguageVersion(), languageSettings::setLanguageVersion);
+                        ifPresent(definition.getLanguageVersion(), languageSettings::setApiVersion);
                     });
                 });
-            });
 
-            // Link JS targets
-            dslModel.getTargetsContainer().getStore().withType(KmpLibraryNodeJsTarget.class).all(target -> {
-                kotlin.js(target.getName(), kotlinTarget -> {
-                    kotlinTarget.nodejs();
-                    KotlinPluginSupport.linkSourceSetToDependencies(
-                            configurations,
-                            kotlinTarget.getCompilations().getByName("main").getDefaultSourceSet(),
-                            target.getDependencies()
-                    );
+                // TODO - figure out how to get rid of this task
+                tasks.configureEach(task -> {
+                    if (task.getName().equals("jvmRun")) {
+                        task.setEnabled(false);
+                    }
                 });
-            });
-
-            // Link Native targets
-            dslModel.getTargetsContainer().getStore().withType(KmpLibraryNativeTarget.class).all(target -> {
-                kotlin.macosArm64(target.getName(), kotlinTarget -> {
-                    KotlinPluginSupport.linkSourceSetToDependencies(
-                            configurations,
-                            kotlinTarget.getCompilations().getByName("main").getDefaultSourceSet(),
-                            target.getDependencies()
-                    );
-                });
-            });
-
-        }
-
-        private static <T> void ifPresent(Property<T> property, Action<T> action) {
-            if (property.isPresent()) {
-                action.execute(property.get());
             }
-        }
 
-        interface Services {
-            @Inject
-            PluginManager getPluginManager();
+            /**
+             * Performs linking actions that do not need to occur within an afterEvaluate block.
+             */
+            private static void linkDslModelToPluginLazy(KmpLibrary dslModel, KotlinMultiplatformBuildModel buildModel, ConfigurationContainer configurations) {
+                KotlinMultiplatformExtension kotlin = buildModel.getKotlinMultiplatformExtension();
 
-            @Inject
-            Project getProject();
+                // Link common dependencies
+                KotlinPluginSupport.linkSourceSetToDependencies(configurations, kotlin.getSourceSets().getByName("commonMain"), dslModel.getDependencies());
+
+                // Link JVM targets
+                dslModel.getTargetsContainer().getStore().withType(KmpLibraryJvmTarget.class).all(target -> {
+                    kotlin.jvm(target.getName(), kotlinTarget -> {
+                        KotlinPluginSupport.linkSourceSetToDependencies(
+                                configurations,
+                                kotlinTarget.getCompilations().getByName("main").getDefaultSourceSet(),
+                                target.getDependencies()
+                        );
+                        kotlinTarget.getCompilations().configureEach(compilation -> {
+                            compilation.getCompilerOptions().getOptions().getJvmTarget().set(target.getJdkVersion().map(value -> JvmTarget.Companion.fromTarget(String.valueOf(value))));
+                        });
+                    });
+                });
+
+                // Link JS targets
+                dslModel.getTargetsContainer().getStore().withType(KmpLibraryNodeJsTarget.class).all(target -> {
+                    kotlin.js(target.getName(), kotlinTarget -> {
+                        kotlinTarget.nodejs();
+                        KotlinPluginSupport.linkSourceSetToDependencies(
+                                configurations,
+                                kotlinTarget.getCompilations().getByName("main").getDefaultSourceSet(),
+                                target.getDependencies()
+                        );
+                    });
+                });
+
+                // Link Native targets
+                dslModel.getTargetsContainer().getStore().withType(KmpLibraryNativeTarget.class).all(target -> {
+                    kotlin.macosArm64(target.getName(), kotlinTarget -> {
+                        KotlinPluginSupport.linkSourceSetToDependencies(
+                                configurations,
+                                kotlinTarget.getCompilations().getByName("main").getDefaultSourceSet(),
+                                target.getDependencies()
+                        );
+                    });
+                });
+
+            }
+
+            private static <T> void ifPresent(Property<T> property, Action<T> action) {
+                if (property.isPresent()) {
+                    action.execute(property.get());
+                }
+            }
         }
     }
 }

--- a/unified-prototype/unified-plugin/plugin-kmp/src/main/java/org/gradle/api/experimental/kotlin/StandaloneKotlinJvmApplicationPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-kmp/src/main/java/org/gradle/api/experimental/kotlin/StandaloneKotlinJvmApplicationPlugin.java
@@ -13,6 +13,8 @@ import org.gradle.api.plugins.PluginManager;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.testing.Test;
 import org.gradle.features.annotations.BindsProjectType;
+import org.gradle.features.binding.ProjectFeatureApplicationContext;
+import org.gradle.features.binding.ProjectTypeApplyAction;
 import org.gradle.features.binding.ProjectTypeBinding;
 import org.gradle.features.binding.ProjectTypeBindingBuilder;
 import org.gradle.features.registration.TaskRegistrar;
@@ -38,56 +40,61 @@ public abstract class StandaloneKotlinJvmApplicationPlugin implements Plugin<Pro
     static class Binding implements ProjectTypeBinding {
         @Override
         public void bind(ProjectTypeBindingBuilder builder) {
-            builder.bindProjectType(KOTLIN_JVM_APPLICATION, KotlinJvmApplication.class,
-                    (context, definition, buildModel) -> {
-                        Services services = context.getObjectFactory().newInstance(Services.class);
-                        services.getPluginManager().apply(ApplicationPlugin.class);
-                        services.getPluginManager().apply("org.jetbrains.kotlin.jvm");
-                        CliExecutablesSupport.configureRunTasks(services.getTaskRegistrar(), buildModel);
-                        ((DefaultKotlinJvmApplicationBuildModel) buildModel).setKotlinJvmExtension(
-                                services.getProject().getExtensions().getByType(KotlinJvmProjectExtension.class)
-                        );
-                        ((DefaultKotlinJvmLibraryBuildModel)buildModel).setJavaPluginExtension(
-                                services.getProject().getExtensions().getByType(JavaPluginExtension.class)
-                        );
-                        ((DefaultKotlinJvmApplicationBuildModel)buildModel).setJavaApplicationExtension(
-                                services.getProject().getExtensions().getByType(JavaApplication.class)
-                        );
-
-                        linkDslModelToPlugin(definition, buildModel, services.getProject().getConfigurations(), services.getProject().getTasks());
-                    })
+            builder.bindProjectType(KOTLIN_JVM_APPLICATION, KotlinJvmApplication.class, ApplyAction.class)
                 .withUnsafeDefinition()
                 .withUnsafeApplyAction()
                 .withBuildModelImplementationType(DefaultKotlinJvmApplicationBuildModel.class);
         }
 
-
-        private void linkDslModelToPlugin(KotlinJvmApplication dslModel, KotlinJvmApplicationBuildModel buildModel, ConfigurationContainer configurations, TaskContainer tasks) {
-            KotlinPluginSupport.linkJavaVersion(dslModel, buildModel.getKotlinJvmExtension());
-            JvmPluginSupport.linkApplicationMainClass(dslModel, buildModel.getJavaApplicationExtension());
-            JvmPluginSupport.linkMainSourceSourceSetDependencies(dslModel.getDependencies(), buildModel.getJavaPluginExtension(), configurations);
-            configureTesting(dslModel, configurations, tasks);
-
-            buildModel.getRunTasks().add(tasks.named("run"));
-        }
-
-        private void configureTesting(KotlinJvmApplication dslModel, ConfigurationContainer configurations, TaskContainer tasks) {
-            configurations.getByName("testImplementation").fromDependencyCollector(dslModel.getTesting().getDependencies().getImplementation());
-            configurations.getByName("testCompileOnly").fromDependencyCollector(dslModel.getTesting().getDependencies().getCompileOnly());
-            configurations.getByName("testRuntimeOnly").fromDependencyCollector(dslModel.getTesting().getDependencies().getRuntimeOnly());
-
-            tasks.withType(Test.class).configureEach(Test::useJUnitPlatform);
-        }
-
-        interface Services {
+        @SuppressWarnings("UnstableApiUsage")
+        static abstract class ApplyAction implements ProjectTypeApplyAction<KotlinJvmApplication, KotlinJvmApplicationBuildModel> {
             @Inject
-            PluginManager getPluginManager();
+            public ApplyAction() {
+            }
 
             @Inject
-            TaskRegistrar getTaskRegistrar();
+            protected abstract PluginManager getPluginManager();
 
             @Inject
-            Project getProject();
+            protected abstract TaskRegistrar getTaskRegistrar();
+
+            @Inject
+            protected abstract Project getProject();
+
+            @Override
+            public void apply(ProjectFeatureApplicationContext context, KotlinJvmApplication definition, KotlinJvmApplicationBuildModel buildModel) {
+                getPluginManager().apply(ApplicationPlugin.class);
+                getPluginManager().apply("org.jetbrains.kotlin.jvm");
+                CliExecutablesSupport.configureRunTasks(getTaskRegistrar(), buildModel);
+                ((DefaultKotlinJvmApplicationBuildModel) buildModel).setKotlinJvmExtension(
+                        getProject().getExtensions().getByType(KotlinJvmProjectExtension.class)
+                );
+                ((DefaultKotlinJvmLibraryBuildModel) buildModel).setJavaPluginExtension(
+                        getProject().getExtensions().getByType(JavaPluginExtension.class)
+                );
+                ((DefaultKotlinJvmApplicationBuildModel) buildModel).setJavaApplicationExtension(
+                        getProject().getExtensions().getByType(JavaApplication.class)
+                );
+
+                linkDslModelToPlugin(definition, buildModel, getProject().getConfigurations(), getProject().getTasks());
+            }
+
+            private void linkDslModelToPlugin(KotlinJvmApplication dslModel, KotlinJvmApplicationBuildModel buildModel, ConfigurationContainer configurations, TaskContainer tasks) {
+                KotlinPluginSupport.linkJavaVersion(dslModel, buildModel.getKotlinJvmExtension());
+                JvmPluginSupport.linkApplicationMainClass(dslModel, buildModel.getJavaApplicationExtension());
+                JvmPluginSupport.linkMainSourceSourceSetDependencies(dslModel.getDependencies(), buildModel.getJavaPluginExtension(), configurations);
+                configureTesting(dslModel, configurations, tasks);
+
+                buildModel.getRunTasks().add(tasks.named("run"));
+            }
+
+            private void configureTesting(KotlinJvmApplication dslModel, ConfigurationContainer configurations, TaskContainer tasks) {
+                configurations.getByName("testImplementation").fromDependencyCollector(dslModel.getTesting().getDependencies().getImplementation());
+                configurations.getByName("testCompileOnly").fromDependencyCollector(dslModel.getTesting().getDependencies().getCompileOnly());
+                configurations.getByName("testRuntimeOnly").fromDependencyCollector(dslModel.getTesting().getDependencies().getRuntimeOnly());
+
+                tasks.withType(Test.class).configureEach(Test::useJUnitPlatform);
+            }
         }
     }
 }

--- a/unified-prototype/unified-plugin/plugin-kmp/src/main/java/org/gradle/api/experimental/kotlin/StandaloneKotlinJvmLibraryPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-kmp/src/main/java/org/gradle/api/experimental/kotlin/StandaloneKotlinJvmLibraryPlugin.java
@@ -10,6 +10,8 @@ import org.gradle.api.plugins.PluginManager;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.testing.Test;
 import org.gradle.features.annotations.BindsProjectType;
+import org.gradle.features.binding.ProjectFeatureApplicationContext;
+import org.gradle.features.binding.ProjectTypeApplyAction;
 import org.gradle.features.binding.ProjectTypeBinding;
 import org.gradle.features.binding.ProjectTypeBindingBuilder;
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension;
@@ -34,46 +36,51 @@ public abstract class StandaloneKotlinJvmLibraryPlugin implements Plugin<Project
     static class Binding implements ProjectTypeBinding {
         @Override
         public void bind(ProjectTypeBindingBuilder builder) {
-            builder.bindProjectType(KOTLIN_JVM_LIBRARY, KotlinJvmLibrary.class,
-                    (context, definition, buildModel) -> {
-                        Services services = context.getObjectFactory().newInstance(Services.class);
-                        services.getPluginManager().apply("org.jetbrains.kotlin.jvm");
-                        ((DefaultKotlinJvmLibraryBuildModel)buildModel).setKotlinJvmExtension(
-                                services.getProject().getExtensions().getByType(KotlinJvmProjectExtension.class)
-                        );
-                        ((DefaultKotlinJvmLibraryBuildModel)buildModel).setJavaPluginExtension(
-                                services.getProject().getExtensions().getByType(JavaPluginExtension.class)
-                        );
-
-                        linkDslModelToPlugin(definition, buildModel, services.getProject().getConfigurations(), services.getProject().getTasks());
-                    })
+            builder.bindProjectType(KOTLIN_JVM_LIBRARY, KotlinJvmLibrary.class, ApplyAction.class)
                 .withUnsafeDefinition()
                 .withUnsafeApplyAction()
                 .withBuildModelImplementationType(DefaultKotlinJvmLibraryBuildModel.class);
         }
 
-
-        private void linkDslModelToPlugin(KotlinJvmLibrary dslModel, KotlinJvmLibraryBuildModel buildModel, ConfigurationContainer configurations, TaskContainer tasks) {
-            KotlinPluginSupport.linkJavaVersion(dslModel, buildModel.getKotlinJvmExtension());
-            JvmPluginSupport.linkMainSourceSourceSetDependencies(dslModel.getDependencies(), buildModel.getJavaPluginExtension(), configurations);
-
-            configureTesting(dslModel, configurations, tasks);
-        }
-
-        private void configureTesting(KotlinJvmLibrary dslModel, ConfigurationContainer configurations, TaskContainer tasks) {
-            configurations.getByName("testImplementation").fromDependencyCollector(dslModel.getTesting().getDependencies().getImplementation());
-            configurations.getByName("testCompileOnly").fromDependencyCollector(dslModel.getTesting().getDependencies().getCompileOnly());
-            configurations.getByName("testRuntimeOnly").fromDependencyCollector(dslModel.getTesting().getDependencies().getRuntimeOnly());
-
-            tasks.withType(Test.class).configureEach(Test::useJUnitPlatform);
-        }
-
-        interface Services {
+        @SuppressWarnings("UnstableApiUsage")
+        static abstract class ApplyAction implements ProjectTypeApplyAction<KotlinJvmLibrary, KotlinJvmLibraryBuildModel> {
             @Inject
-            PluginManager getPluginManager();
+            public ApplyAction() {
+            }
 
             @Inject
-            Project getProject();
+            protected abstract PluginManager getPluginManager();
+
+            @Inject
+            protected abstract Project getProject();
+
+            @Override
+            public void apply(ProjectFeatureApplicationContext context, KotlinJvmLibrary definition, KotlinJvmLibraryBuildModel buildModel) {
+                getPluginManager().apply("org.jetbrains.kotlin.jvm");
+                ((DefaultKotlinJvmLibraryBuildModel) buildModel).setKotlinJvmExtension(
+                        getProject().getExtensions().getByType(KotlinJvmProjectExtension.class)
+                );
+                ((DefaultKotlinJvmLibraryBuildModel) buildModel).setJavaPluginExtension(
+                        getProject().getExtensions().getByType(JavaPluginExtension.class)
+                );
+
+                linkDslModelToPlugin(definition, buildModel, getProject().getConfigurations(), getProject().getTasks());
+            }
+
+            private void linkDslModelToPlugin(KotlinJvmLibrary dslModel, KotlinJvmLibraryBuildModel buildModel, ConfigurationContainer configurations, TaskContainer tasks) {
+                KotlinPluginSupport.linkJavaVersion(dslModel, buildModel.getKotlinJvmExtension());
+                JvmPluginSupport.linkMainSourceSourceSetDependencies(dslModel.getDependencies(), buildModel.getJavaPluginExtension(), configurations);
+
+                configureTesting(dslModel, configurations, tasks);
+            }
+
+            private void configureTesting(KotlinJvmLibrary dslModel, ConfigurationContainer configurations, TaskContainer tasks) {
+                configurations.getByName("testImplementation").fromDependencyCollector(dslModel.getTesting().getDependencies().getImplementation());
+                configurations.getByName("testCompileOnly").fromDependencyCollector(dslModel.getTesting().getDependencies().getCompileOnly());
+                configurations.getByName("testRuntimeOnly").fromDependencyCollector(dslModel.getTesting().getDependencies().getRuntimeOnly());
+
+                tasks.withType(Test.class).configureEach(Test::useJUnitPlatform);
+            }
         }
     }
 }

--- a/unified-prototype/unified-plugin/plugin-kmp/src/main/resources/templates/kotlin-application/settings.gradle.dcl
+++ b/unified-prototype/unified-plugin/plugin-kmp/src/main/resources/templates/kotlin-application/settings.gradle.dcl
@@ -5,7 +5,7 @@ pluginManagement {
 }
 
 plugins {
-    id("org.gradle.experimental.kmp-ecosystem").version("0.1.58")
+    id("org.gradle.experimental.kmp-ecosystem").version("0.1.59")
 }
 
 dependencyResolutionManagement {

--- a/unified-prototype/unified-plugin/plugin-plugin/src/main/java/org/gradle/api/experimental/plugin/JavaGradlePluginPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-plugin/src/main/java/org/gradle/api/experimental/plugin/JavaGradlePluginPlugin.java
@@ -5,6 +5,8 @@ import org.gradle.api.Project;
 import org.gradle.api.experimental.plugin.internal.DefaultJaveGradlePluginBuildModel;
 import org.gradle.api.plugins.PluginManager;
 import org.gradle.features.annotations.BindsProjectType;
+import org.gradle.features.binding.ProjectFeatureApplicationContext;
+import org.gradle.features.binding.ProjectTypeApplyAction;
 import org.gradle.features.binding.ProjectTypeBinding;
 import org.gradle.features.binding.ProjectTypeBindingBuilder;
 import org.gradle.plugin.devel.GradlePluginDevelopmentExtension;
@@ -23,15 +25,32 @@ public abstract class JavaGradlePluginPlugin implements Plugin<Project> {
     static class Binding implements ProjectTypeBinding {
         @Override
         public void bind(ProjectTypeBindingBuilder builder) {
-            builder.bindProjectType(JAVA_GRADLE_PLUGIN, JavaGradlePlugin.class, (context, definition, buildModel) -> {
-                Services services = context.getObjectFactory().newInstance(Services.class);
+            builder.bindProjectType(JAVA_GRADLE_PLUGIN, JavaGradlePlugin.class, ApplyAction.class)
+                .withUnsafeDefinition()
+                .withUnsafeApplyAction()
+                .withBuildModelImplementationType(DefaultJaveGradlePluginBuildModel.class);
+        }
 
-                services.getPluginManager().apply("java-gradle-plugin");
+        @SuppressWarnings("UnstableApiUsage")
+        static abstract class ApplyAction implements ProjectTypeApplyAction<JavaGradlePlugin, JavaGradlePluginBuildModel> {
+            @Inject
+            public ApplyAction() {
+            }
 
-                ((DefaultJaveGradlePluginBuildModel)buildModel).setDevelopmentExtension(
-                    services.getProject().getExtensions().getByType(GradlePluginDevelopmentExtension.class));
+            @Inject
+            protected abstract PluginManager getPluginManager();
 
-                services.getProject().afterEvaluate(project -> {
+            @Inject
+            protected abstract Project getProject();
+
+            @Override
+            public void apply(ProjectFeatureApplicationContext context, JavaGradlePlugin definition, JavaGradlePluginBuildModel buildModel) {
+                getPluginManager().apply("java-gradle-plugin");
+
+                ((DefaultJaveGradlePluginBuildModel) buildModel).setDevelopmentExtension(
+                    getProject().getExtensions().getByType(GradlePluginDevelopmentExtension.class));
+
+                getProject().afterEvaluate(project -> {
                     project.setDescription(definition.getDescription().get());
                     project.getConfigurations().getByName("api").fromDependencyCollector(definition.getDependencies().getApi());
                     project.getConfigurations().getByName("implementation").fromDependencyCollector(definition.getDependencies().getImplementation());
@@ -45,18 +64,7 @@ public abstract class JavaGradlePluginPlugin implements Plugin<Project> {
                         });
                     });
                 });
-            })
-            .withUnsafeDefinition()
-            .withUnsafeApplyAction()
-            .withBuildModelImplementationType(DefaultJaveGradlePluginBuildModel.class);
-        }
-
-        interface Services {
-            @Inject
-            PluginManager getPluginManager();
-
-            @Inject
-            Project getProject();
+            }
         }
     }
 

--- a/unified-prototype/unified-plugin/plugin-swift/src/main/java/org/gradle/api/experimental/swift/StandaloneSwiftApplicationPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-swift/src/main/java/org/gradle/api/experimental/swift/StandaloneSwiftApplicationPlugin.java
@@ -11,6 +11,8 @@ import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Exec;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.features.annotations.BindsProjectType;
+import org.gradle.features.binding.ProjectFeatureApplicationContext;
+import org.gradle.features.binding.ProjectTypeApplyAction;
 import org.gradle.features.binding.ProjectTypeBinding;
 import org.gradle.features.binding.ProjectTypeBindingBuilder;
 import org.gradle.features.registration.TaskRegistrar;
@@ -31,49 +33,56 @@ public abstract class StandaloneSwiftApplicationPlugin implements Plugin<Project
     static class Binding implements ProjectTypeBinding {
         @Override
         public void bind(ProjectTypeBindingBuilder builder) {
-            builder.bindProjectType(SWIFT_APPLICATION, SwiftApplication.class, (context, definition, buildModel) -> {
-                Services services = context.getObjectFactory().newInstance(Services.class);
-                services.getPluginManager().apply(SwiftApplicationPlugin.class);
-                CliExecutablesSupport.configureRunTasks(services.getTaskRegistrar(), buildModel);
-
-                ((DefaultSwiftApplicationBuildModel)buildModel).setSwiftComponent(services.getProject().getExtensions().getByType(SwiftComponent.class));
-
-                linkDefinitionToPlugin(services.getProject(), definition, buildModel);
-            })
-            .withUnsafeDefinition()
-            .withUnsafeApplyAction()
-            .withBuildModelImplementationType(DefaultSwiftApplicationBuildModel.class);
+            builder.bindProjectType(SWIFT_APPLICATION, SwiftApplication.class, ApplyAction.class)
+                .withUnsafeDefinition()
+                .withUnsafeApplyAction()
+                .withBuildModelImplementationType(DefaultSwiftApplicationBuildModel.class);
         }
 
-        private void linkDefinitionToPlugin(Project project, SwiftApplication definition, SwiftApplicationBuildModel buildModel) {
-            SwiftComponent model = buildModel.getSwiftComponent();
-            SwiftPluginSupport.linkSwiftVersion(definition, model);
+        @SuppressWarnings("UnstableApiUsage")
+        static abstract class ApplyAction implements ProjectTypeApplyAction<SwiftApplication, SwiftApplicationBuildModel> {
+            @Inject
+            public ApplyAction() {
+            }
 
-            model.getImplementationDependencies().getDependencies().addAllLater(definition.getDependencies().getImplementation().getDependencies());
+            @Inject
+            protected abstract PluginManager getPluginManager();
 
-            project.afterEvaluate(p -> {
-                for (SwiftBinary binary : model.getBinaries().get()) {
-                    if (binary instanceof SwiftExecutable) {
-                        Provider<RegularFile> executable = ((SwiftExecutable) binary).getDebuggerExecutableFile();
-                        TaskProvider<Exec> runTask = project.getTasks().register("run" + TextUtil.capitalize(binary.getName()), Exec.class, task -> {
-                            task.executable(executable.get().getAsFile().getAbsoluteFile());
-                            task.dependsOn(executable);
-                        });
-                        buildModel.getRunTasks().add(runTask);
+            @Inject
+            protected abstract TaskRegistrar getTaskRegistrar();
+
+            @Inject
+            protected abstract Project getProject();
+
+            @Override
+            public void apply(ProjectFeatureApplicationContext context, SwiftApplication definition, SwiftApplicationBuildModel buildModel) {
+                getPluginManager().apply(SwiftApplicationPlugin.class);
+                CliExecutablesSupport.configureRunTasks(getTaskRegistrar(), buildModel);
+
+                ((DefaultSwiftApplicationBuildModel) buildModel).setSwiftComponent(getProject().getExtensions().getByType(SwiftComponent.class));
+
+                linkDefinitionToPlugin(getProject(), definition, buildModel);
+            }
+
+            private void linkDefinitionToPlugin(Project project, SwiftApplication definition, SwiftApplicationBuildModel buildModel) {
+                SwiftComponent model = buildModel.getSwiftComponent();
+                SwiftPluginSupport.linkSwiftVersion(definition, model);
+
+                model.getImplementationDependencies().getDependencies().addAllLater(definition.getDependencies().getImplementation().getDependencies());
+
+                project.afterEvaluate(p -> {
+                    for (SwiftBinary binary : model.getBinaries().get()) {
+                        if (binary instanceof SwiftExecutable) {
+                            Provider<RegularFile> executable = ((SwiftExecutable) binary).getDebuggerExecutableFile();
+                            TaskProvider<Exec> runTask = project.getTasks().register("run" + TextUtil.capitalize(binary.getName()), Exec.class, task -> {
+                                task.executable(executable.get().getAsFile().getAbsoluteFile());
+                                task.dependsOn(executable);
+                            });
+                            buildModel.getRunTasks().add(runTask);
+                        }
                     }
-                }
-            });
-        }
-
-        interface Services {
-            @Inject
-            PluginManager getPluginManager();
-
-            @Inject
-            TaskRegistrar getTaskRegistrar();
-
-            @Inject
-            Project getProject();
+                });
+            }
         }
     }
 

--- a/unified-prototype/unified-plugin/plugin-swift/src/main/java/org/gradle/api/experimental/swift/StandaloneSwiftLibraryPlugin.java
+++ b/unified-prototype/unified-plugin/plugin-swift/src/main/java/org/gradle/api/experimental/swift/StandaloneSwiftLibraryPlugin.java
@@ -6,6 +6,8 @@ import org.gradle.api.experimental.swift.internal.DefaultSwiftLibraryBuildModel;
 import org.gradle.api.experimental.swift.internal.SwiftPluginSupport;
 import org.gradle.api.plugins.PluginManager;
 import org.gradle.features.annotations.BindsProjectType;
+import org.gradle.features.binding.ProjectFeatureApplicationContext;
+import org.gradle.features.binding.ProjectTypeApplyAction;
 import org.gradle.features.binding.ProjectTypeBinding;
 import org.gradle.features.binding.ProjectTypeBindingBuilder;
 import org.gradle.language.swift.plugins.SwiftLibraryPlugin;
@@ -21,33 +23,40 @@ public abstract class StandaloneSwiftLibraryPlugin implements Plugin<Project> {
     static class Binding implements ProjectTypeBinding {
         @Override
         public void bind(ProjectTypeBindingBuilder builder) {
-            builder.bindProjectType(SWIFT_LIBRARY, SwiftLibrary.class, (context, definition, buildModel) -> {
-                Services services = context.getObjectFactory().newInstance(Services.class);
-                services.getPluginManager().apply(SwiftLibraryPlugin.class);
+            builder.bindProjectType(SWIFT_LIBRARY, SwiftLibrary.class, ApplyAction.class)
+                .withUnsafeDefinition()
+                .withUnsafeApplyAction()
+                .withBuildModelImplementationType(DefaultSwiftLibraryBuildModel.class);
+        }
 
-                ((DefaultSwiftLibraryBuildModel) buildModel).setSwiftLibrary(services.getProject().getExtensions().getByType(org.gradle.language.swift.SwiftLibrary.class));
+        @SuppressWarnings("UnstableApiUsage")
+        static abstract class ApplyAction implements ProjectTypeApplyAction<SwiftLibrary, SwiftLibraryBuildModel> {
+            @Inject
+            public ApplyAction() {
+            }
+
+            @Inject
+            protected abstract PluginManager getPluginManager();
+
+            @Inject
+            protected abstract Project getProject();
+
+            @Override
+            public void apply(ProjectFeatureApplicationContext context, SwiftLibrary definition, SwiftLibraryBuildModel buildModel) {
+                getPluginManager().apply(SwiftLibraryPlugin.class);
+
+                ((DefaultSwiftLibraryBuildModel) buildModel).setSwiftLibrary(getProject().getExtensions().getByType(org.gradle.language.swift.SwiftLibrary.class));
 
                 linkDefinitionToPlugin(definition, buildModel);
-            })
-            .withUnsafeDefinition()
-            .withUnsafeApplyAction()
-            .withBuildModelImplementationType(DefaultSwiftLibraryBuildModel.class);
-        }
+            }
 
-        private void linkDefinitionToPlugin(SwiftLibrary definition, SwiftLibraryBuildModel buildModel) {
-            org.gradle.language.swift.SwiftLibrary model = buildModel.getSwiftLibrary();
-            SwiftPluginSupport.linkSwiftVersion(definition, model);
+            private void linkDefinitionToPlugin(SwiftLibrary definition, SwiftLibraryBuildModel buildModel) {
+                org.gradle.language.swift.SwiftLibrary model = buildModel.getSwiftLibrary();
+                SwiftPluginSupport.linkSwiftVersion(definition, model);
 
-            model.getImplementationDependencies().getDependencies().addAllLater(definition.getDependencies().getImplementation().getDependencies());
-            model.getApiDependencies().getDependencies().addAllLater(definition.getDependencies().getApi().getDependencies());
-        }
-
-        interface Services {
-            @Inject
-            PluginManager getPluginManager();
-
-            @Inject
-            Project getProject();
+                model.getImplementationDependencies().getDependencies().addAllLater(definition.getDependencies().getImplementation().getDependencies());
+                model.getApiDependencies().getDependencies().addAllLater(definition.getDependencies().getApi().getDependencies());
+            }
         }
     }
 


### PR DESCRIPTION
Updates projects to Gradle 9.6.0:
- Use apply action classes instead of lambdas
- Treat definition as immutable in apply action