### PR TITLE
Update signing configuration for PGP subkey

### DIFF
--- a/unified-prototype/unified-plugin/build-logic/src/main/kotlin/build-logic.publishing.gradle.kts
+++ b/unified-prototype/unified-plugin/build-logic/src/main/kotlin/build-logic.publishing.gradle.kts
@@ -10,6 +10,8 @@ gradlePlugin {
 
 signing {
     useInMemoryPgpKeys(
+        // Key ID required when signing with a subkey
+        project.providers.environmentVariable("PGP_SIGNING_KEY_ID").orNull,
         project.providers.environmentVariable("PGP_SIGNING_KEY").orNull,
         project.providers.environmentVariable("PGP_SIGNING_KEY_PASSPHRASE").orNull
     )


### PR DESCRIPTION
After the move to a signing subkey following the August 14 security incident, `useInMemoryPgpKeys` needs the key ID as its first argument — without it the signing plugin falls back to the primary key.

This adds the key ID to the `signing {}` block and, where the repo owns the build configuration, makes it pass `env.PGP_SIGNING_KEY_ID`. Matches gradle/gradle#38874 and the other Gradle-org repos.

The `pgpSigningKeyId` parameter is already inherited from the parent TeamCity project, so no new secret is needed.

Docs: https://docs.gradle.org/current/userguide/signing_plugin.html#sec:subkeys
Part of gradle/gradle-private#5321